### PR TITLE
Add a result type

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,7 @@ hst_LDADD = libhst.la
 # are checked before larger features that build on them.
 check_PROGRAMS = \
 	tests/test-harness \
+	tests/test-results \
 	tests/test-events \
 	tests/test-lts \
 	tests/test-operators
@@ -44,5 +45,6 @@ tests_test_events_LDFLAGS = -no-install
 tests_test_harness_LDFLAGS = -no-install
 tests_test_lts_LDFLAGS = -no-install
 tests_test_operators_LDFLAGS = -no-install
+tests_test_results_LDFLAGS = -no-install
 
 dist_doc_DATA = README.md

--- a/tests/test-cases.h
+++ b/tests/test-cases.h
@@ -149,9 +149,9 @@ fail();
 
 // Verify that two values or objects are equal, failing the current test case if
 // not.
-template <typename T>
+template <typename T, typename E>
 void
-check_eq(const T& actual, const T& expected)
+check_eq(const T& actual, const E& expected)
 {
     if (actual != expected) {
         fail() << "Expected " << expected << ", got " << actual;
@@ -160,9 +160,9 @@ check_eq(const T& actual, const T& expected)
 
 // Verify that two values or objects are NOT equal, failing the current test
 // case if not.
-template <typename T>
+template <typename T, typename E>
 void
-check_ne(const T& actual, const T& expected)
+check_ne(const T& actual, const E& expected)
 {
     if (actual == expected) {
         fail() << "Didn't expect " << expected;

--- a/tests/test-results.cc
+++ b/tests/test-results.cc
@@ -1,0 +1,42 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2016, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#include "test-cases.h"
+#include "test-harness.cc.in"
+
+#include "hst.h"
+
+using hst::Result;
+using std::string;
+
+static Result<int, string>
+good(int value)
+{
+    return value;
+}
+
+static Result<int, string>
+bad()
+{
+    return string("Returning an error");
+}
+
+TEST_CASE_GROUP("results");
+
+TEST_CASE("can produce a successful result")
+{
+    Result<int, string> result = good(12);
+    check_eq(result.valid(), true);
+    check_eq(result.get(), 12);
+}
+
+TEST_CASE("can produce a failed result")
+{
+    Result<int, string> result = bad();
+    check_eq(result.valid(), false);
+    check_eq(result.get_error(), "Returning an error");
+}


### PR DESCRIPTION
This is inspired by Rust's `Result<T,E>` type and by Haskell's `Either` monad.  It lets you write a function that returns a value if it succeeds, and a description of an error if it fails, all in a single return value.  A glorified tagged union.