### PR TITLE
Make test case failures fail fast

### DIFF
--- a/tests/test-cases.cc
+++ b/tests/test-cases.cc
@@ -34,6 +34,12 @@ void TestRegistry::run_all()
 SingleResultTestCase* SingleResultTestCase::current_test_case_ = nullptr;
 
 void
+SingleResultTestCase::abort()
+{
+    throw test_case_aborted();
+}
+
+void
 SingleResultTestCase::run(unsigned int index)
 {
     // Assume the test case passes unless we're told otherwise.
@@ -41,7 +47,11 @@ SingleResultTestCase::run(unsigned int index)
 
     // Run the test.
     current_test_case_ = this;
-    body();
+    try{
+        body();
+    } catch (const test_case_aborted& e) {
+        succeeded_ = false;
+    }
     current_test_case_ = nullptr;
 
     // Report the result.
@@ -66,4 +76,11 @@ std::ostream&
 fail()
 {
     return tests::SingleResultTestCase::current_test_case().mark_failed();
+}
+
+std::ostream&
+operator<<(std::ostream& out, const abort_test& abort)
+{
+    tests::SingleResultTestCase::current_test_case().abort();
+    return out;
 }

--- a/tests/test-cases.h
+++ b/tests/test-cases.h
@@ -59,6 +59,9 @@ class SingleResultTestCase : public TestStep {
     // with the reason for the failure.
     std::ostream& mark_failed();
 
+    // Aborts the current test case.
+    void abort();
+
     // The currently running test case.
     static SingleResultTestCase& current_test_case()
     {
@@ -81,6 +84,10 @@ class SingleResultTestCase : public TestStep {
     const std::string description_;
     bool succeeded_;
     std::stringstream failure_reason_;
+
+  private:
+    class test_case_aborted : public std::exception {
+    };
 };
 
 // A test step that prints out a comment without running any actual tests.  This
@@ -140,6 +147,17 @@ class TestCaseGroup : public TestStep {
 #define HERE  __FILE__, __LINE__
 
 //------------------------------------------------------------------------------
+// Aborting the test
+
+// If you want to abort your test after a failed test, pipe this into fail()
+// right after your error message.
+class abort_test {
+};
+
+std::ostream&
+operator<<(std::ostream& out, const abort_test& abort);
+
+//------------------------------------------------------------------------------
 // Common checks
 
 // Mark the current test case as failing.
@@ -153,7 +171,7 @@ void
 check_eq(const T& actual, const T& expected)
 {
     if (actual != expected) {
-        fail() << "Expected " << expected << ", got " << actual;
+        fail() << "Expected " << expected << ", got " << actual << abort_test();
     }
 }
 
@@ -164,7 +182,7 @@ void
 check_ne(const T& actual, const T& expected)
 {
     if (actual == expected) {
-        fail() << "Didn't expect " << expected;
+        fail() << "Didn't expect " << expected << abort_test();
     }
 }
 


### PR DESCRIPTION
The test assertion routines should (generally) immediately abort the current test case if they fail, since later portions of the test case will typically depend on the assertion being true.  We now use exceptions to abort the current test case immediately when an assertion fails.  (Using exceptions means we don't need macros, and we can fail from arbitrarily deep in the call stack.)