### PR TITLE
Use shared_ptrs to hold processes

### DIFF
--- a/src/hst/prefix.cc
+++ b/src/hst/prefix.cc
@@ -15,6 +15,20 @@
 
 namespace hst {
 
+class ConcretePrefix : public Prefix {
+  public:
+    ConcretePrefix(Event a, std::shared_ptr<Process> p)
+        : Prefix(a, std::move(p))
+    {
+    }
+};
+
+std::shared_ptr<Prefix>
+Prefix::create(Event a, std::shared_ptr<Process> p)
+{
+    return std::make_shared<ConcretePrefix>(a, std::move(p));
+}
+
 void
 Prefix::initials(std::set<Event>* out)
 {
@@ -22,7 +36,7 @@ Prefix::initials(std::set<Event>* out)
 }
 
 void
-Prefix::afters(Event initial, std::set<Process*>* out)
+Prefix::afters(Event initial, Process::Set* out)
 {
     if (initial == a_) {
         out->insert(p_);

--- a/src/hst/prefix.h
+++ b/src/hst/prefix.h
@@ -18,7 +18,7 @@ namespace hst {
 
 class Prefix : public Process {
   public:
-    Prefix(Event a, Process* p) : a_(a), p_(p) {}
+    static std::shared_ptr<Prefix> create(Event a, std::shared_ptr<Process> p);
 
     // Fill `out` with the initial events of this process.
     void initials(Event::Set* out) override;
@@ -30,9 +30,12 @@ class Prefix : public Process {
     unsigned int precedence() const override { return 1; }
     void print(std::ostream& out) const override;
 
+  protected:
+    Prefix(Event a, std::shared_ptr<Process> p) : a_(a), p_(p) {}
+
   private:
     Event a_;
-    Process* p_;
+    std::shared_ptr<Process> p_;
 };
 
 }  // namespace hst

--- a/src/hst/process.h
+++ b/src/hst/process.h
@@ -8,6 +8,7 @@
 #ifndef HST_PROCESS_H
 #define HST_PROCESS_H
 
+#include <memory>
 #include <ostream>
 #include <set>
 
@@ -17,7 +18,7 @@ namespace hst {
 
 class Process {
   public:
-    using Set = std::set<Process*>;
+    using Set = std::set<std::shared_ptr<Process>>;
 
     virtual ~Process() = default;
 

--- a/src/hst/stop.cc
+++ b/src/hst/stop.cc
@@ -7,16 +7,20 @@
 
 #include "hst/stop.h"
 
+#include <memory>
+
 #include "hst/event.h"
 #include "hst/process.h"
 
 namespace hst {
 
-Stop*
-Stop::get()
+class ConcreteStop : public Stop {};
+
+std::shared_ptr<Stop>
+Stop::create()
 {
-    static Stop stop;
-    return &stop;
+    static std::shared_ptr<Stop> stop = std::make_shared<ConcreteStop>();
+    return stop;
 }
 
 void

--- a/src/hst/stop.h
+++ b/src/hst/stop.h
@@ -8,6 +8,8 @@
 #ifndef HST_STOP_H
 #define HST_STOP_H
 
+#include <memory>
+
 #include "hst/event.h"
 #include "hst/process.h"
 
@@ -15,14 +17,14 @@ namespace hst {
 
 class Stop : public Process {
   public:
-    static Stop* get();
+    static std::shared_ptr<Stop> create();
 
     void initials(Event::Set* out) override;
     void afters(Event initial, Process::Set* out) override;
     unsigned int precedence() const override { return 1; }
     void print(std::ostream& out) const override;
 
-  private:
+  protected:
     Stop() = default;
 };
 

--- a/tests/test-operators.cc
+++ b/tests/test-operators.cc
@@ -34,7 +34,7 @@ events_from_names(std::initializer_list<const std::string> names)
 }
 
 void
-check_initials(Process* process,
+check_initials(const std::shared_ptr<Process>& process,
                std::initializer_list<const std::string> expected)
 {
     Event::Set actual;
@@ -43,8 +43,9 @@ check_initials(Process* process,
 }
 
 void
-check_afters(Process* process, const std::string& initial,
-             std::initializer_list<Process*> expected)
+check_afters(const std::shared_ptr<Process>& process,
+             const std::string& initial,
+             std::initializer_list<std::shared_ptr<Process>> expected)
 {
     Process::Set actual;
     process->afters(Event(initial), &actual);
@@ -57,17 +58,17 @@ TEST_CASE_GROUP("prefix");
 
 TEST_CASE("a → STOP")
 {
-    Prefix p(Event("a"), Stop::get());
-    check_initials(&p, {"a"});
-    check_afters(&p, "a", {Stop::get()});
-    check_afters(&p, "τ", {});
+    auto p = Prefix::create(Event("a"), Stop::create());
+    check_initials(p, {"a"});
+    check_afters(p, "a", {Stop::create()});
+    check_afters(p, "τ", {});
 }
 
 TEST_CASE_GROUP("STOP");
 
 TEST_CASE("STOP")
 {
-    Stop* stop = Stop::get();
+    auto stop = Stop::create();
     check_initials(stop, {});
     check_afters(stop, "a", {});
     check_afters(stop, "τ", {});


### PR DESCRIPTION
We get reference counting for "free", and until I have data showing that the reference counting costs too much, I'm going to stick with it.