### PR TITLE
Hold processes in a hash set

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,7 @@ LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/tap-driver.sh
 libhst_la_SOURCES = \
 	src/hst/event.h \
 	src/hst/event.cc \
+	src/hst/hash.h \
 	src/hst/prefix.h \
 	src/hst/prefix.cc \
 	src/hst/process.h \

--- a/src/hst/event.h
+++ b/src/hst/event.h
@@ -52,4 +52,18 @@ std::ostream& operator<<(std::ostream& out, const Event& event);
 std::ostream& operator<<(std::ostream& out, const Event::Set& events);
 
 }  // namespace hst
+
+namespace std {
+
+template <>
+struct hash<hst::Event>
+{
+    std::size_t operator()(const hst::Event& event) const
+    {
+        return std::hash<string>()(event.name());
+    }
+};
+
+}  // namespace std
+
 #endif  // HST_EVENT_H

--- a/src/hst/hash.h
+++ b/src/hst/hash.h
@@ -1,0 +1,42 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef HST_HASH_H
+#define HST_HASH_H
+
+#include <functional>
+
+namespace hst {
+
+// You can't do anything with these; they just exist, and give you a nice basis
+// for forming distinct hash values.
+class hash_scope {
+};
+
+class hasher {
+  public:
+    explicit hasher(const hash_scope& scope)
+        : hash_(std::hash<const void*>()(&scope))
+    {
+    }
+
+    template <typename T>
+    hasher& add(const T& value)
+    {
+        hash_ ^= std::hash<T>()(value) + 0x9e3779b9 + (hash_ << 6) +
+                 (hash_ >> 2);
+        return *this;
+    }
+
+    std::size_t value() const { return hash_; }
+
+  private:
+    std::size_t hash_;
+};
+
+}  // namespace hst
+#endif  // HST_HASH_H

--- a/src/hst/prefix.cc
+++ b/src/hst/prefix.cc
@@ -11,6 +11,7 @@
 #include <set>
 
 #include "hst/event.h"
+#include "hst/hash.h"
 #include "hst/process.h"
 
 namespace hst {
@@ -41,6 +42,23 @@ Prefix::afters(Event initial, Process::Set* out)
     if (initial == a_) {
         out->insert(p_);
     }
+}
+
+std::size_t
+Prefix::hash() const
+{
+    static hash_scope prefix;
+    return hasher(prefix).add(a_).add(*p_).value();
+}
+
+bool
+Prefix::operator==(const Process& other_) const
+{
+    const Prefix* other = dynamic_cast<const Prefix*>(&other_);
+    if (other == nullptr) {
+        return false;
+    }
+    return a_ == other->a_ && *p_ == *other->p_;
 }
 
 void

--- a/src/hst/prefix.h
+++ b/src/hst/prefix.h
@@ -20,13 +20,11 @@ class Prefix : public Process {
   public:
     static std::shared_ptr<Prefix> create(Event a, std::shared_ptr<Process> p);
 
-    // Fill `out` with the initial events of this process.
     void initials(Event::Set* out) override;
-
-    // Fill `out` with the subprocesses that you reach after following a single
-    // `initial` event from this process.
     void afters(Event initial, Process::Set* out) override;
 
+    std::size_t hash() const override;
+    bool operator==(const Process& other) const override;
     unsigned int precedence() const override { return 1; }
     void print(std::ostream& out) const override;
 

--- a/src/hst/process.cc
+++ b/src/hst/process.cc
@@ -9,6 +9,20 @@
 
 namespace hst {
 
+bool
+operator==(const Process::Set& lhs, const Process::Set& rhs)
+{
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+    for (const auto& process : lhs) {
+        if (rhs.find(process) == rhs.end()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 std::ostream& operator<<(std::ostream& out, const Process::Set& processes)
 {
     bool first = true;

--- a/src/hst/stop.cc
+++ b/src/hst/stop.cc
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include "hst/event.h"
+#include "hst/hash.h"
 #include "hst/process.h"
 
 namespace hst {
@@ -31,6 +32,23 @@ Stop::initials(Event::Set* out)
 void
 Stop::afters(Event initial, Process::Set* out)
 {
+}
+
+std::size_t
+Stop::hash() const
+{
+    static hash_scope stop;
+    return hasher(stop).value();
+}
+
+bool
+Stop::operator==(const Process& other_) const
+{
+    const Stop* other = dynamic_cast<const Stop*>(&other_);
+    if (other == nullptr) {
+        return false;
+    }
+    return true;
 }
 
 void

--- a/src/hst/stop.h
+++ b/src/hst/stop.h
@@ -21,6 +21,9 @@ class Stop : public Process {
 
     void initials(Event::Set* out) override;
     void afters(Event initial, Process::Set* out) override;
+
+    std::size_t hash() const override;
+    bool operator==(const Process& other) const override;
     unsigned int precedence() const override { return 1; }
     void print(std::ostream& out) const override;
 

--- a/tests/test-operators.cc
+++ b/tests/test-operators.cc
@@ -54,6 +54,26 @@ check_afters(const std::shared_ptr<Process>& process,
 
 }  // namespace
 
+TEST_CASE_GROUP("process comparisons");
+
+TEST_CASE("can compare individual processes")
+{
+    auto p1 = Prefix::create(Event("a"), Stop::create());
+    auto p2 = Prefix::create(Event("a"), Stop::create());
+    check_eq(*p1, *p1);
+    check_eq(*p1, *p2);
+}
+
+TEST_CASE("can compare sets of processes")
+{
+    auto p1 = Prefix::create(Event("a"), Stop::create());
+    auto p2 = Prefix::create(Event("a"), Stop::create());
+    Process::Set set1{p1};
+    Process::Set set2{p2};
+    check_eq(set1, set1);
+    check_eq(set1, set2);
+}
+
 TEST_CASE_GROUP("prefix");
 
 TEST_CASE("a → STOP")


### PR DESCRIPTION
This also overrides the default == operator for Process::Set, since that doesn't use your key comparison function to compare the elements for some reason!