### PR TITLE
Add initial CSP₀ parser

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,6 +15,8 @@ LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/tap-driver.sh
 @VALGRIND_CHECK_RULES@
 
 libhst_la_SOURCES = \
+	src/hst/csp0.h \
+	src/hst/csp0.cc \
 	src/hst/event.h \
 	src/hst/event.cc \
 	src/hst/hash.h \
@@ -34,6 +36,7 @@ hst_LDADD = libhst.la
 check_PROGRAMS = \
 	tests/test-harness \
 	tests/test-events \
+	tests/test-csp0 \
 	tests/test-operators
 
 check_LTLIBRARIES = libtests.la
@@ -43,6 +46,7 @@ libtests_la_SOURCES = \
 	tests/test-harness.cc.in
 
 LDADD = libhst.la libtests.la
+tests_test_csp0_LDFLAGS = -no-install
 tests_test_events_LDFLAGS = -no-install
 tests_test_harness_LDFLAGS = -no-install
 tests_test_operators_LDFLAGS = -no-install

--- a/src/hst/csp0.cc
+++ b/src/hst/csp0.cc
@@ -1,0 +1,395 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2016-2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#include "hst/csp0.h"
+
+#include <cassert>
+#include <functional>
+#include <string>
+
+#include "hst/event.h"
+#include "hst/prefix.h"
+#include "hst/process.h"
+#include "hst/stop.h"
+
+//------------------------------------------------------------------------------
+// Debugging nonsense
+
+#if defined(DEBUG_CSP0)
+#include <iostream>
+#endif
+
+class DebugStream {
+  public:
+    ~DebugStream() {
+#if defined(DEBUG_CSP0)
+        std::cerr << std::endl;
+#endif
+    }
+
+    template <typename T>
+    DebugStream& operator<<(const T& value)
+    {
+#if defined(DEBUG_CSP0)
+        std::cerr << value;
+#endif
+        return *this;
+    }
+};
+
+static DebugStream
+debug()
+{
+    return DebugStream();
+}
+
+struct hex {
+    unsigned char ch;
+    hex(char ch) : ch(ch) {}
+};
+
+#if defined(DEBUG_CSP0)
+static std::ostream&
+operator<<(std::ostream& out, hex ch)
+{
+    unsigned char high_nybble = (ch.ch & 0xf0) >> 4;
+    unsigned char low_nybble = ch.ch & 0x0f;
+    return out << (char) (high_nybble >= 10 ? high_nybble - 10 + 'a' :
+                                              high_nybble + '0')
+               << (char) (low_nybble >= 10 ? low_nybble - 10 + 'a' :
+                                             low_nybble + '0');
+}
+#endif
+
+//------------------------------------------------------------------------------
+// Branch prediction
+
+// TODO: Implement these
+#define likely(x) (x)
+#define unlikely(x) (x)
+
+//------------------------------------------------------------------------------
+// The actual parser
+
+namespace hst {
+
+#define return_if_success(call) \
+    do {                        \
+        auto __result = (call); \
+        if (__result) {         \
+            return __result;    \
+        }                       \
+    } while (0)
+
+#define return_if_error(call)   \
+    do {                        \
+        auto __result = (call); \
+        if (!__result) {        \
+            return __result;    \
+        }                       \
+    } while (0)
+
+class ParseState {
+  public:
+    explicit ParseState(const std::string& csp0) : ParseState(csp0, nullptr) {}
+    ParseState(const std::string& csp0, ParseError* error)
+        : parent_(nullptr),
+          start_(csp0.data()),
+          p_(csp0.data()),
+          eof_(p_ + csp0.size()),
+          error_(error)
+    {
+    }
+
+    ~ParseState()
+    {
+        if (parent_) {
+            if (failed_) {
+                debug() << "FAIL   " << label_;
+            } else {
+                debug() << "PASS   " << label_;
+            }
+        }
+        if (parent_ && !failed_) {
+            parent_->p_ = p_;
+        }
+    }
+
+    char get();
+    bool get(char* out);
+
+    bool parse_error(const std::string& message)
+    {
+        fail();
+        error_->set_message(message);
+        debug() << "ERROR  " << label_ << ": " << message;
+        return false;
+    }
+
+    bool eof() const { return p_ == eof_; }
+    void fail() { failed_ = true; }
+    size_t remaining() const { return eof_ - p_; }
+
+    // Return a std::string containing whichever characters were successfully
+    // parsed using this ParseState.
+    std::string as_string() const { return std::string(start_, p_ - start_); }
+
+    // Returns a new ParseState that lets you implement a limited form of
+    // backtracking.  The new ParseState will point at the same position in the
+    // original input as this.  Use the new ParseState to attempt to parse some
+    // part of the grammar.  If that succeeds, when the new ParseState goes out
+    // of scope, it will update this to skip over whatever you successfully
+    // parsed out of the new ParseState.  If it fails, call its fail() method
+    // before it goes out of scope; that will prevent it from updating this.
+    ParseState attempt(const std::string& label)
+    {
+        return ParseState(this, label, p_, p_, eof_, error_);
+    }
+
+  private:
+    ParseState(ParseState* parent, const std::string& label, const char* start,
+               const char* p, const char* eof, ParseError* error)
+        : parent_(parent),
+          label_(label),
+          start_(start),
+          p_(p),
+          eof_(eof),
+          error_(error)
+    {
+        debug() << "START  " << label_;
+    }
+
+    ParseState* parent_;
+    const std::string label_;
+    const char* start_;
+    const char* p_;
+    const char* eof_;
+    bool failed_ = false;
+    ParseError* error_;
+};
+
+inline char
+ParseState::get()
+{
+    assert(p_ < eof_);
+    char ch = *p_++;
+    if (!label_.empty()) {
+        debug() << "[" << hex(ch) << " "
+                << (((unsigned char) ch) < 0x80 ? ch : '*') << "] " << label_;
+    }
+    return ch;
+}
+
+inline bool
+ParseState::get(char* out)
+{
+    if (unlikely(p_ == eof_)) {
+        return parse_error("Unexpected end of input");
+    }
+    *out = get();
+    return true;
+}
+
+template <typename F>
+static void
+skip_while(ParseState* parent, const std::string& label, F pred)
+{
+    ParseState state = parent->attempt(label);
+    // As long as there are more characters to consume...
+    while (likely(!state.eof())) {
+        // Try to consume one character.
+        ParseState ch = state.attempt(label);
+        if (!pred(ch.get())) {
+            // If it doesn't match the predicate, then return this character to
+            // the stream and return.
+            ch.fail();
+            return;
+        }
+    }
+}
+
+static void
+skip_whitespace(ParseState* state)
+{
+    skip_while(state, "whitespace", [](char ch) -> bool {
+        return ch == ' ' || ch == '\f' || ch == '\n' || ch == '\r' ||
+               ch == '\t' || ch == '\v';
+    });
+}
+
+static bool
+is_idstart(char ch)
+{
+    return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_';
+}
+
+static bool
+is_idchar(char ch)
+{
+    return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
+           (ch >= '0' && ch <= '9') || ch == '_' || ch == '.';
+}
+
+static bool
+parse_dollar_identifier(ParseState* parent, std::string* out)
+{
+    ParseState state = parent->attempt("dollar identifier");
+    char ch;
+    // Parse the leading $
+    return_if_error(state.get(&ch));
+    if (unlikely(ch != '$')) {
+        return state.parse_error("Expected a $");
+    }
+    // A $ identifier must contain at least one character after the $
+    return_if_error(state.get(&ch));
+    if (unlikely(!is_idchar(ch))) {
+        return state.parse_error("Expected at least one ID characater after $");
+    }
+    // Parse any additional characters in the identifier
+    skip_while(&state, "dollar identifier character", is_idchar);
+    *out = state.as_string();
+    return true;
+}
+
+static bool
+parse_regular_identifier(ParseState* parent, std::string* out)
+{
+    ParseState state = parent->attempt("regular identifier");
+    char ch;
+    // Parse the leading identifier character
+    return_if_error(state.get(&ch));
+    if (unlikely(!is_idstart(ch))) {
+        return state.parse_error("Expected a letter or underscore");
+    }
+    // Parse any additional characters in the identifier
+    skip_while(&state, "regular identifier character", is_idchar);
+    *out = state.as_string();
+    return true;
+}
+
+static bool
+parse_identifier(ParseState* state, std::string* out)
+{
+    return_if_success(parse_regular_identifier(state, out));
+    return_if_success(parse_dollar_identifier(state, out));
+    return state->parse_error("Expected an identifier");
+}
+
+static bool
+require_token(ParseState* parent, const std::string& expected_str)
+{
+    ParseState expected(expected_str);
+    if (unlikely(parent->remaining() < expected.remaining())) {
+        return parent->parse_error("Expected " + expected_str);
+    }
+    ParseState state = parent->attempt(expected_str);
+    while (!expected.eof()) {
+        if (unlikely(state.get() != expected.get())) {
+            return state.parse_error("Expected " + expected_str);
+        }
+    }
+    return true;
+}
+
+static bool
+parse_process(ParseState* state, std::shared_ptr<Process>* out);
+
+// Precedence order (tightest first)
+//  1. () STOP SKIP
+//  2. → identifier
+//  3. ;
+//  4. timeout
+//  5. interrupt
+//  6. □ (infix)
+//  7. ⊓ (infix)
+//  8. ||
+//  9. |||
+// 10. \ (hiding)
+// 11. replicated operators (prefix)
+// 12. let
+
+// Each of these numbered parse_process functions corresponds to one of the
+// entries in the precedence order list.
+
+static bool
+parse_parenthesized(ParseState* state, std::shared_ptr<Process>* out)
+{
+    return_if_error(require_token(state, "("));
+    skip_whitespace(state);
+    return_if_error(parse_process(state, out));
+    skip_whitespace(state);
+    return_if_error(require_token(state, ")"));
+    return true;
+}
+
+static bool
+parse_stop(ParseState* state, std::shared_ptr<Process>* out)
+{
+    return_if_error(require_token(state, "STOP"));
+    *out = Stop::create();
+    return true;
+}
+
+static bool
+parse_process1(ParseState* parent, std::shared_ptr<Process>* out)
+{
+    // process1 = (process) | STOP | SKIP
+    ParseState state = parent->attempt("process1");
+    return_if_success(parse_parenthesized(&state, out));
+    return_if_success(parse_stop(&state, out));
+    return state.parse_error("Expected (, STOP, or SKIP");
+}
+
+static bool
+parse_process2(ParseState* parent, std::shared_ptr<Process>* out)
+{
+    // process2 = process1 | identifier | event → process2
+    return_if_success(parse_process1(parent, out));
+
+    ParseState state = parent->attempt("process2");
+    std::string id;
+    return_if_error(parse_identifier(&state, &id));
+    skip_whitespace(&state);
+
+    // prefix
+    if (require_token(&state, "->") || require_token(&state, "→")) {
+        Event initial(id);
+        std::shared_ptr<Process> after;
+        skip_whitespace(&state);
+        return_if_error(parse_process2(&state, &after));
+        *out = Prefix::create(initial, std::move(after));
+        return true;
+    }
+
+    return state.parse_error("Undefined process " + id);
+}
+
+static bool
+parse_process(ParseState* state, std::shared_ptr<Process>* out)
+{
+    return parse_process2(state, out);
+}
+
+std::shared_ptr<Process>
+load_csp0_string(const std::string& csp0, ParseError* error)
+{
+    ParseState state(csp0, error);
+    skip_whitespace(&state);
+    debug() << "--- " << csp0;
+    std::shared_ptr<Process> result;
+    if (unlikely(!parse_process(&state, &result))) {
+        return nullptr;
+    }
+    skip_whitespace(&state);
+    if (unlikely(!state.eof())) {
+        state.parse_error("Unexpected characters at end of input");
+        return nullptr;
+    }
+    return std::move(result);
+}
+
+}  // namespace hst

--- a/src/hst/csp0.h
+++ b/src/hst/csp0.h
@@ -1,0 +1,37 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2016-2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef HST_CSP0_H
+#define HST_CSP0_H
+
+#include <memory>
+#include <ostream>
+#include <string>
+
+#include "hst/process.h"
+
+namespace hst {
+
+//------------------------------------------------------------------------------
+// CSP₀
+
+struct ParseError {
+    std::string message;
+    void set_message(const std::string& message) { this->message = message; }
+};
+
+inline std::ostream&
+operator<<(std::ostream& out, const ParseError& error)
+{
+    return out << error.message;
+}
+
+std::shared_ptr<Process>
+load_csp0_string(const std::string& csp0, ParseError* error);
+
+}  // namespace hst
+#endif  // HST_CSP0_H

--- a/tests/test-csp0.cc
+++ b/tests/test-csp0.cc
@@ -1,0 +1,142 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2016-2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#include "hst/csp0.h"
+
+#include <string>
+
+#include "test-cases.h"
+#include "test-harness.cc.in"
+
+#include "hst/event.h"
+#include "hst/prefix.h"
+#include "hst/process.h"
+#include "hst/stop.h"
+
+// Don't check the semantics of any of the operators here; this file just checks
+// that the CSP₀ parser produces the same processes that you'd get constructing
+// things by hand.  Look in test-operators.cc for test cases that verify that
+// each operator behaves as we expect it to.
+
+using hst::Event;
+using hst::ParseError;
+using hst::Prefix;
+using hst::Process;
+using hst::Stop;
+
+static void
+check_csp0_valid(const std::string& csp0)
+{
+    ParseError error;
+    if (!hst::load_csp0_string(csp0, &error)) {
+        fail() << "Could not parse " << csp0 << ": " << error << abort_test();
+    }
+}
+
+static void
+check_csp0_invalid(const std::string& csp0)
+{
+    ParseError error;
+    if (hst::load_csp0_string(csp0, &error)) {
+        fail() << "Shouldn't be able to parse " << csp0 << abort_test();
+    }
+}
+
+static void
+check_csp0_eq(const std::string& csp0, const std::shared_ptr<Process>& expected)
+{
+    ParseError error;
+    std::shared_ptr<Process> actual = hst::load_csp0_string(csp0, &error);
+    if (!actual) {
+        fail() << "Could not parse " << csp0 << ": " << error << abort_test();
+    }
+    check_eq(*actual, *expected);
+}
+
+TEST_CASE_GROUP("CSP₀ syntax");
+
+TEST_CASE("can parse identifiers")
+{
+    // Parse a bunch of valid identifiers.
+    check_csp0_valid("r → STOP");
+    check_csp0_valid("r0 → STOP");
+    check_csp0_valid("r0r → STOP");
+    check_csp0_valid("root → STOP");
+    check_csp0_valid("root.root → STOP");
+    check_csp0_valid("root_root → STOP");
+    check_csp0_valid("_ → STOP");
+    check_csp0_valid("_r → STOP");
+    check_csp0_valid("_r0 → STOP");
+    check_csp0_valid("_r0r → STOP");
+    check_csp0_valid("_root → STOP");
+    check_csp0_valid("_root.root → STOP");
+    check_csp0_valid("_root_root → STOP");
+    check_csp0_valid("$r → STOP");
+    check_csp0_valid("$r0 → STOP");
+    check_csp0_valid("$r0r → STOP");
+    check_csp0_valid("$root → STOP");
+    check_csp0_valid("$root.root → STOP");
+    check_csp0_valid("$root_root → STOP");
+    // Fail to parse a bunch of invalid identifiers.
+    check_csp0_invalid("0 → STOP");
+    check_csp0_invalid("$ → STOP");
+}
+
+TEST_CASE_GROUP("CSP₀ primitives");
+
+TEST_CASE("parse: STOP")
+{
+    auto expected = Stop::create();
+    check_csp0_eq("STOP", expected);
+    check_csp0_eq(" STOP", expected);
+    check_csp0_eq("STOP ", expected);
+    check_csp0_eq(" STOP ", expected);
+}
+
+TEST_CASE_GROUP("CSP₀ operators");
+
+TEST_CASE("parse: (STOP)")
+{
+    auto expected = Stop::create();
+    check_csp0_eq("(STOP)", expected);
+    check_csp0_eq(" (STOP)", expected);
+    check_csp0_eq(" ( STOP)", expected);
+    check_csp0_eq(" ( STOP )", expected);
+    check_csp0_eq(" ( STOP ) ", expected);
+    check_csp0_eq("((STOP))", expected);
+    check_csp0_eq("(((STOP)))", expected);
+}
+
+TEST_CASE("parse: a → STOP")
+{
+    auto expected = Prefix::create(Event("a"), Stop::create());
+    check_csp0_eq("a->STOP", expected);
+    check_csp0_eq(" a->STOP", expected);
+    check_csp0_eq(" a ->STOP", expected);
+    check_csp0_eq(" a -> STOP", expected);
+    check_csp0_eq(" a -> STOP ", expected);
+    check_csp0_eq("a→STOP", expected);
+    check_csp0_eq(" a→STOP", expected);
+    check_csp0_eq(" a →STOP", expected);
+    check_csp0_eq(" a → STOP", expected);
+    check_csp0_eq(" a → STOP ", expected);
+    // Fail to parse a bunch of invalid statements.
+    // STOP isn't an event
+    check_csp0_invalid("STOP → STOP");
+    // undefined isn't defined
+    check_csp0_invalid("a → undefined");
+    // b isn't a process (reported as "b is undefined")
+    check_csp0_invalid("(a → b) → STOP");
+}
+
+TEST_CASE("associativity: a → b → STOP")
+{
+    auto expected = Prefix::create(Event("a"),
+                                   Prefix::create(Event("b"), Stop::create()));
+    check_csp0_eq("a -> b -> STOP", expected);
+    check_csp0_eq("a → b → STOP", expected);
+}


### PR DESCRIPTION
This is a simple language for defining processes, not the full CSPM with its embedded functional programming language.  We're using a simple recursive descent parser.  Right now we only support the primitive processes (STOP), parentheses, and prefix (→).
