### PR TITLE
Add a less-optimized Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,12 @@ branches:
   only:
     - master
 
-# Test both in-source and out-of-source builds.
+# Test both in-source and out-of-source builds, as well as mildly optimized vs
+# wildly optimized.
 env:
   - BUILD_TYPE=in_source
   - BUILD_TYPE=out_of_source
+  - BUILD_TYPE=hella_optimized
 
 language: cpp
 script: .travis/test.sh

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -13,8 +13,20 @@ if [ "$CXX" = "g++" ]; then
 fi
 
 ${srcdir}/autogen.sh
-${srcdir}/configure --enable-valgrind CXXFLAGS="-g -O3 -flto" LDFLAGS="-flto"
+if [ ${BUILD_TYPE} = hella_optimized ]; then
+    ${srcdir}/configure --enable-valgrind \
+        CPPFLAGS="-DNDEBUG" \
+        CXXFLAGS="-O3 -flto -march=native" \
+        LDFLAGS="-flto -march=native"
+else
+    ${srcdir}/configure --enable-valgrind CXXFLAGS="-g -Os"
+fi
 make
 make check
 make check-valgrind
-make distcheck
+
+# distcheck doesn't pass on our optimization settings, so we don't need to run
+# it during the hella-optimized build.
+if [ ${BUILD_TYPE} != hella_optimized ]; then
+    make distcheck
+fi


### PR DESCRIPTION
Actually, two — the existing in-source/out-of-source builds now turn off link-time optimization, and drop down to -Os from -O3.  There's a new "hella optimized" build that turns off debugging symbols and assertions, and keeps the link-time optimization.