### PR TITLE
Use const in process references

### DIFF
--- a/src/hst/csp0.h
+++ b/src/hst/csp0.h
@@ -31,7 +31,7 @@ operator<<(std::ostream& out, const ParseError& error)
     return out << error.message;
 }
 
-Process*
+const Process*
 load_csp0_string(Environment* env, const std::string& csp0, ParseError* error);
 
 }  // namespace hst

--- a/src/hst/environment.cc
+++ b/src/hst/environment.cc
@@ -15,9 +15,9 @@ namespace {
 
 class Skip : public Process {
   public:
-    explicit Skip(Process* stop) : stop_(stop) {}
-    void initials(Event::Set* out) override;
-    void afters(Event initial, Process::Set* out) override;
+    explicit Skip(const Process* stop) : stop_(stop) {}
+    void initials(Event::Set* out) const override;
+    void afters(Event initial, Process::Set* out) const override;
 
     std::size_t hash() const override;
     bool operator==(const Process& other) const override;
@@ -25,19 +25,19 @@ class Skip : public Process {
     void print(std::ostream& out) const override;
 
   private:
-    Process* stop_;
+    const Process* stop_;
 };
 
 }  // namespace
 
 void
-Skip::initials(Event::Set* out)
+Skip::initials(Event::Set* out) const
 {
     out->insert(Event::tick());
 }
 
 void
-Skip::afters(Event initial, Process::Set* out)
+Skip::afters(Event initial, Process::Set* out) const
 {
     if (initial == Event::tick()) {
         out->insert(stop_);
@@ -73,8 +73,8 @@ class Stop : public Process {
   public:
     Stop() = default;
 
-    void initials(Event::Set* out) override;
-    void afters(Event initial, Process::Set* out) override;
+    void initials(Event::Set* out) const override;
+    void afters(Event initial, Process::Set* out) const override;
 
     std::size_t hash() const override;
     bool operator==(const Process& other) const override;
@@ -85,12 +85,12 @@ class Stop : public Process {
 }  // namespace
 
 void
-Stop::initials(Event::Set* out)
+Stop::initials(Event::Set* out) const
 {
 }
 
 void
-Stop::afters(Event initial, Process::Set* out)
+Stop::afters(Event initial, Process::Set* out) const
 {
 }
 
@@ -123,7 +123,7 @@ Environment::Environment()
     skip_ = register_process(std::unique_ptr<Process>(new Skip(stop_)));
 }
 
-Process*
+const Process*
 Environment::register_process(std::unique_ptr<Process> process)
 {
     auto result = registry_.insert(std::move(process));

--- a/src/hst/environment.h
+++ b/src/hst/environment.h
@@ -19,16 +19,16 @@ class Environment {
   public:
     Environment();
 
-    Process* external_choice(Process* p, Process* q);
-    Process* external_choice(Process::Set ps);
-    Process* interleave(Process* p, Process* q);
-    Process* interleave(Process::Bag ps);
-    Process* internal_choice(Process* p, Process* q);
-    Process* internal_choice(Process::Set ps);
-    Process* prefix(Event a, Process* p);
-    Process* sequential_composition(Process* p, Process* q);
-    Process* skip() const { return skip_; }
-    Process* stop() const { return stop_; }
+    const Process* external_choice(const Process* p, const Process* q);
+    const Process* external_choice(Process::Set ps);
+    const Process* interleave(const Process* p, const Process* q);
+    const Process* interleave(Process::Bag ps);
+    const Process* internal_choice(const Process* p, const Process* q);
+    const Process* internal_choice(Process::Set ps);
+    const Process* prefix(Event a, const Process* p);
+    const Process* sequential_composition(const Process* p, const Process* q);
+    const Process* skip() const { return skip_; }
+    const Process* stop() const { return stop_; }
 
   private:
     struct deref_hash {
@@ -51,11 +51,11 @@ class Environment {
 
     // Ensures that there is exactly one process in the registry equal to
     // `process`, returning a pointer to that process.
-    Process* register_process(std::unique_ptr<Process> process);
+    const Process* register_process(std::unique_ptr<Process> process);
 
     Registry registry_;
-    Process* skip_;
-    Process* stop_;
+    const Process* skip_;
+    const Process* stop_;
 };
 
 }  // namespace hst

--- a/src/hst/internal-choice.cc
+++ b/src/hst/internal-choice.cc
@@ -21,8 +21,8 @@ namespace {
 class InternalChoice : public Process {
   public:
     explicit InternalChoice(Process::Set ps) : ps_(std::move(ps)) {}
-    void initials(Event::Set* out) override;
-    void afters(Event initial, Process::Set* out) override;
+    void initials(Event::Set* out) const override;
+    void afters(Event initial, Process::Set* out) const override;
 
     std::size_t hash() const override;
     bool operator==(const Process& other) const override;
@@ -35,15 +35,15 @@ class InternalChoice : public Process {
 
 }  // namespace
 
-Process*
+const Process*
 Environment::internal_choice(Process::Set ps)
 {
     return register_process(
             std::unique_ptr<Process>(new InternalChoice(std::move(ps))));
 }
 
-Process*
-Environment::internal_choice(Process* p, Process* q)
+const Process*
+Environment::internal_choice(const Process* p, const Process* q)
 {
     return internal_choice(Process::Set{p, q});
 }
@@ -54,14 +54,14 @@ Environment::internal_choice(Process* p, Process* q)
 //     ⊓ Ps -τ→ P
 
 void
-InternalChoice::initials(Event::Set* out)
+InternalChoice::initials(Event::Set* out) const
 {
     // initials(⊓ Ps) = {τ}
     out->insert(Event::tau());
 }
 
 void
-InternalChoice::afters(Event initial, Process::Set* out)
+InternalChoice::afters(Event initial, Process::Set* out) const
 {
     // afters(⊓ Ps, τ) = Ps
     if (initial == Event::tau()) {

--- a/src/hst/prefix.cc
+++ b/src/hst/prefix.cc
@@ -20,9 +20,9 @@ namespace {
 
 class Prefix : public Process {
   public:
-    Prefix(Event a, Process* p) : a_(a), p_(p) {}
-    void initials(Event::Set* out) override;
-    void afters(Event initial, Process::Set* out) override;
+    Prefix(Event a, const Process* p) : a_(a), p_(p) {}
+    void initials(Event::Set* out) const override;
+    void afters(Event initial, Process::Set* out) const override;
 
     std::size_t hash() const override;
     bool operator==(const Process& other) const override;
@@ -31,13 +31,13 @@ class Prefix : public Process {
 
   private:
     Event a_;
-    Process* p_;
+    const Process* p_;
 };
 
 }  // namespace
 
-Process*
-Environment::prefix(Event a, Process* p)
+const Process*
+Environment::prefix(Event a, const Process* p)
 {
     return register_process(std::unique_ptr<Process>(new Prefix(a, p)));
 }
@@ -48,14 +48,14 @@ Environment::prefix(Event a, Process* p)
 //     a → P -a→ P
 
 void
-Prefix::initials(std::set<Event>* out)
+Prefix::initials(std::set<Event>* out) const
 {
     // initials(a → P) = {a}
     out->insert(a_);
 }
 
 void
-Prefix::afters(Event initial, Process::Set* out)
+Prefix::afters(Event initial, Process::Set* out) const
 {
     // afters(a → P, a) = P
     if (initial == a_) {

--- a/src/hst/process.cc
+++ b/src/hst/process.cc
@@ -23,7 +23,7 @@ operator==(const Process::Bag& lhs, const Process::Bag& rhs)
     if (lhs.size() != rhs.size()) {
         return false;
     }
-    for (const auto& process : lhs) {
+    for (const Process* process : lhs) {
         if (rhs.find(process) == rhs.end()) {
             return false;
         }
@@ -36,7 +36,7 @@ std::ostream& operator<<(std::ostream& out, const Process::Bag& processes)
     // We want reproducible output, so we sort the names of the processes in the
     // set before rendering them into the stream.
     std::vector<std::string> process_names;
-    for (const auto& process : processes) {
+    for (const Process* process : processes) {
         std::stringstream name;
         name << *process;
         process_names.emplace_back(name.str());
@@ -45,7 +45,7 @@ std::ostream& operator<<(std::ostream& out, const Process::Bag& processes)
 
     bool first = true;
     out << "{";
-    for (auto process : process_names) {
+    for (const auto& process : process_names) {
         if (first) {
             first = false;
         } else {
@@ -61,7 +61,7 @@ hash(const Process::Bag& set)
 {
     static hash_scope scope;
     hasher hash(scope);
-    for (const auto& process : set) {
+    for (const Process* process : set) {
         hash.add_unordered(*process);
     }
     return hash.value();
@@ -73,7 +73,7 @@ operator==(const Process::Set& lhs, const Process::Set& rhs)
     if (lhs.size() != rhs.size()) {
         return false;
     }
-    for (const auto& process : lhs) {
+    for (const Process* process : lhs) {
         if (rhs.find(process) == rhs.end()) {
             return false;
         }
@@ -86,7 +86,7 @@ std::ostream& operator<<(std::ostream& out, const Process::Set& processes)
     // We want reproducible output, so we sort the names of the processes in the
     // set before rendering them into the stream.
     std::vector<std::string> process_names;
-    for (const auto& process : processes) {
+    for (const Process* process : processes) {
         std::stringstream name;
         name << *process;
         process_names.emplace_back(name.str());
@@ -95,7 +95,7 @@ std::ostream& operator<<(std::ostream& out, const Process::Set& processes)
 
     bool first = true;
     out << "{";
-    for (auto process : process_names) {
+    for (const auto& process : process_names) {
         if (first) {
             first = false;
         } else {
@@ -111,7 +111,7 @@ hash(const Process::Set& set)
 {
     static hash_scope scope;
     hasher hash(scope);
-    for (const auto& process : set) {
+    for (const Process* process : set) {
         hash.add_unordered(*process);
     }
     return hash.value();

--- a/src/hst/process.h
+++ b/src/hst/process.h
@@ -25,17 +25,17 @@ namespace hst {
 
 class Process {
   public:
-    using Bag = std::unordered_multiset<Process*>;
-    using Set = std::unordered_set<Process*>;
+    using Bag = std::unordered_multiset<const Process*>;
+    using Set = std::unordered_set<const Process*>;
 
     virtual ~Process() = default;
 
     // Fill `out` with the initial events of this process.
-    virtual void initials(Event::Set* out) = 0;
+    virtual void initials(Event::Set* out) const = 0;
 
     // Fill `out` with the subprocesses that you reach after following a single
     // `initial` event from this process.
-    virtual void afters(Event initial, Set* out) = 0;
+    virtual void afters(Event initial, Set* out) const = 0;
 
     virtual std::size_t hash() const = 0;
     virtual bool operator==(const Process& other) const = 0;

--- a/src/hst/sequential-composition.cc
+++ b/src/hst/sequential-composition.cc
@@ -20,13 +20,13 @@ namespace {
 
 class SequentialComposition : public Process {
   public:
-    SequentialComposition(Environment* env, Process* p, Process* q)
+    SequentialComposition(Environment* env, const Process* p, const Process* q)
         : env_(env), p_(p), q_(q)
     {
     }
 
-    void initials(Event::Set* out) override;
-    void afters(Event initial, Process::Set* out) override;
+    void initials(Event::Set* out) const override;
+    void afters(Event initial, Process::Set* out) const override;
 
     std::size_t hash() const override;
     bool operator==(const Process& other) const override;
@@ -35,14 +35,14 @@ class SequentialComposition : public Process {
 
   private:
     Environment* env_;
-    Process* p_;
-    Process* q_;
+    const Process* p_;
+    const Process* q_;
 };
 
 }  // namespace
 
-Process*
-Environment::sequential_composition(Process* p, Process* q)
+const Process*
+Environment::sequential_composition(const Process* p, const Process* q)
 {
     return register_process(
             std::unique_ptr<Process>(new SequentialComposition(this, p, q)));
@@ -59,7 +59,7 @@ Environment::sequential_composition(Process* p, Process* q)
 //       P;Q -τ→ Q
 
 void
-SequentialComposition::initials(std::set<Event>* out)
+SequentialComposition::initials(std::set<Event>* out) const
 {
     // 1) P;Q can perform all of the same events as P, except for ✔.
     // 2) If P can perform ✔, then P;Q can perform τ.
@@ -73,7 +73,7 @@ SequentialComposition::initials(std::set<Event>* out)
 }
 
 void
-SequentialComposition::afters(Event initial, Process::Set* out)
+SequentialComposition::afters(Event initial, Process::Set* out) const
 {
     // afters(P;Q a ≠ ✔) = afters(P, a)                                 [rule 1]
     // afters(P;Q, τ) = Q  if ✔ ∈ initials(P)                           [rule 2]
@@ -93,7 +93,7 @@ SequentialComposition::afters(Event initial, Process::Set* out)
     {
         Process::Set afters;
         p_->afters(initial, &afters);
-        for (const auto& p_prime : afters) {
+        for (const Process* p_prime : afters) {
             out->insert(env_->sequential_composition(p_prime, q_));
         }
     }

--- a/tests/test-csp0.cc
+++ b/tests/test-csp0.cc
@@ -47,10 +47,11 @@ check_csp0_invalid(const std::string& csp0)
 }
 
 static void
-check_csp0_eq(Environment* env, const std::string& csp0, Process* expected)
+check_csp0_eq(Environment* env, const std::string& csp0,
+              const Process* expected)
 {
     ParseError error;
-    Process* actual = hst::load_csp0_string(env, csp0, &error);
+    const Process* actual = hst::load_csp0_string(env, csp0, &error);
     if (!actual) {
         fail() << "Could not parse " << csp0 << ": " << error << abort_test();
     }

--- a/tests/test-operators.cc
+++ b/tests/test-operators.cc
@@ -32,11 +32,11 @@ using hst::Process;
 
 namespace {
 
-Process*
+const Process*
 require_csp0(Environment* env, const std::string& csp0)
 {
     ParseError error;
-    Process* parsed = hst::load_csp0_string(env, csp0, &error);
+    const Process* parsed = hst::load_csp0_string(env, csp0, &error);
     if (!parsed) {
         fail() << "Could not parse " << csp0 << ": " << error << abort_test();
     }
@@ -68,7 +68,7 @@ void
 check_name(const std::string& csp0, const std::string& expected)
 {
     Environment env;
-    Process* process = require_csp0(&env, csp0);
+    const Process* process = require_csp0(&env, csp0);
     std::stringstream actual;
     actual << *process;
     check_eq(actual.str(), expected);
@@ -79,7 +79,7 @@ check_initials(const std::string& csp0,
                std::initializer_list<const std::string> expected)
 {
     Environment env;
-    Process* process = require_csp0(&env, csp0);
+    const Process* process = require_csp0(&env, csp0);
     Event::Set actual;
     process->initials(&actual);
     check_eq(actual, events_from_names(expected));
@@ -90,7 +90,7 @@ check_afters(const std::string& csp0, const std::string& initial,
              std::initializer_list<const std::string> expected)
 {
     Environment env;
-    Process* process = require_csp0(&env, csp0);
+    const Process* process = require_csp0(&env, csp0);
     Process::Set actual;
     process->afters(Event(initial), &actual);
     check_eq(actual, require_csp0_set(&env, expected));


### PR DESCRIPTION
Once they're created you can't do anything to them anyway, so lets be more explicit about that.