### PR TITLE
Calculate reachable subprocesses

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,9 @@ libhst_la_SOURCES = \
 	src/hst/sequential-composition.cc
 
 hst_SOURCES = \
-	src/hst/hst/hst.cc
+	src/hst/hst/command.h \
+	src/hst/hst/hst.cc \
+	src/hst/hst/reachable.cc
 hst_LDADD = libhst.la
 
 # Keep this sorted generally in order of dependency, so that more basic features

--- a/src/hst/hst/command.h
+++ b/src/hst/hst/command.h
@@ -1,0 +1,33 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef HST_COMMAND_H
+#define HST_COMMAND_H
+
+#include <string>
+
+namespace hst {
+
+class Command {
+  public:
+    explicit Command(std::string name) : name_(name) {}
+    virtual ~Command() = default;
+    const std::string& name() const { return name_; }
+    virtual void run(int argc, char** argv) = 0;
+
+  private:
+    std::string name_;
+};
+
+class Reachable : public Command {
+  public:
+    Reachable() : Command("reachable") {}
+    void run(int argc, char** argv) override;
+};
+
+}  // namespace hst
+#endif  // HST_COMMAND_H

--- a/src/hst/hst/hst.cc
+++ b/src/hst/hst/hst.cc
@@ -5,8 +5,33 @@
  * -----------------------------------------------------------------------------
  */
 
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+#include "hst/hst/command.h"
+
+static hst::Reachable reachable;
+static std::vector<hst::Command*> commands{&reachable};
+
 int
 main(int argc, char** argv)
 {
-    return 0;
+    if (argc <= 1) {
+        std::cerr << "Usage: hst [command]" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    argc--, argv++; /* Executable name */
+    std::string desired_command(*argv);
+
+    for (hst::Command* command : commands) {
+        if (desired_command == command->name()) {
+            command->run(argc, argv);
+            exit(EXIT_SUCCESS);
+        }
+    }
+
+    std::cerr << "Unknown command " << desired_command << std::endl;
+    exit(EXIT_FAILURE);
 }

--- a/src/hst/hst/reachable.cc
+++ b/src/hst/hst/reachable.cc
@@ -1,0 +1,74 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#include "hst/hst/command.h"
+
+#include <getopt.h>
+#include <iostream>
+#include <string>
+
+#include "hst/csp0.h"
+#include "hst/environment.h"
+#include "hst/process.h"
+
+namespace hst {
+
+void
+Reachable::run(int argc, char** argv)
+{
+    bool verbose = false;
+    static struct option options[] = {{"verbose", no_argument, 0, 'v'},
+                                      {0, 0, 0, 0}};
+
+    while (true) {
+        int option_index = 0;
+        int c = getopt_long(argc, argv, "v", options, &option_index);
+        if (c == -1) {
+            break;
+        }
+
+        switch (c) {
+            case 'v':
+                verbose = true;
+                break;
+
+            default:
+                exit(EXIT_FAILURE);
+        }
+    }
+    argc -= optind, argv += optind;
+
+    if (argc != 1) {
+        std::cerr << "Usage: hst reachable [-v] <process>" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    std::string csp0((argc--, *argv++));
+    Environment env;
+    ParseError error;
+    const Process* process = load_csp0_string(&env, csp0, &error);
+    if (process == nullptr) {
+        std::cerr << "Invalid CSP₀ process \"" << csp0 << "\":" << std::endl
+                  << error << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    unsigned long count = 0;
+    process->bfs([&count, verbose](const Process* process) {
+        if (verbose) {
+            std::cout << *process << std::endl;
+        }
+        count++;
+        return true;
+    });
+    if (verbose) {
+        std::cout << "Reachable processes: ";
+    }
+    std::cout << count << std::endl;
+}
+
+}  // namespace

--- a/tests/test-cases.h
+++ b/tests/test-cases.h
@@ -171,7 +171,8 @@ void
 check_eq(const T& actual, const T& expected)
 {
     if (actual != expected) {
-        fail() << "Expected " << expected << ", got " << actual << abort_test();
+        fail() << "Expected " << expected << std::endl
+               << "# Got      " << actual << abort_test();
     }
 }
 


### PR DESCRIPTION
This new method does a breadth-first walk from a process, saving all of the reachable subprocesses into a set.  Great for test cases.