### PR TITLE
Use real classes for sets and bags

### DIFF
--- a/src/hst/event.h
+++ b/src/hst/event.h
@@ -20,7 +20,7 @@ namespace hst {
 
 class Event {
   public:
-    using Set = std::set<Event>;
+    class Set;
 
     explicit Event(const std::string& name) : index_(find_or_create_event(name))
     {
@@ -61,6 +61,15 @@ class Event {
 };
 
 std::ostream& operator<<(std::ostream& out, const Event& event);
+
+class Event::Set : public std::set<Event> {
+  private:
+    using Parent = std::set<Event>;
+
+  public:
+    using Parent::set;
+};
+
 std::ostream& operator<<(std::ostream& out, const Event::Set& events);
 
 }  // namespace hst

--- a/src/hst/prefix.cc
+++ b/src/hst/prefix.cc
@@ -48,7 +48,7 @@ Environment::prefix(Event a, const Process* p)
 //     a → P -a→ P
 
 void
-Prefix::initials(std::set<Event>* out) const
+Prefix::initials(Event::Set* out) const
 {
     // initials(a → P) = {a}
     out->insert(a_);

--- a/src/hst/process.cc
+++ b/src/hst/process.cc
@@ -17,6 +17,17 @@
 
 namespace hst {
 
+std::size_t
+Process::Bag::hash() const
+{
+    static hash_scope scope;
+    hst::hasher hash(scope);
+    for (const Process* process : *this) {
+        hash.add_unordered(*process);
+    }
+    return hash.value();
+}
+
 bool
 operator==(const Process::Bag& lhs, const Process::Bag& rhs)
 {
@@ -57,11 +68,11 @@ std::ostream& operator<<(std::ostream& out, const Process::Bag& processes)
 }
 
 std::size_t
-hash(const Process::Bag& set)
+Process::Set::hash() const
 {
     static hash_scope scope;
-    hasher hash(scope);
-    for (const Process* process : set) {
+    hst::hasher hash(scope);
+    for (const Process* process : *this) {
         hash.add_unordered(*process);
     }
     return hash.value();
@@ -104,17 +115,6 @@ std::ostream& operator<<(std::ostream& out, const Process::Set& processes)
         out << process;
     }
     return out << "}";
-}
-
-std::size_t
-hash(const Process::Set& set)
-{
-    static hash_scope scope;
-    hasher hash(scope);
-    for (const Process* process : set) {
-        hash.add_unordered(*process);
-    }
-    return hash.value();
 }
 
 }  // namespace hst

--- a/src/hst/process.h
+++ b/src/hst/process.h
@@ -25,8 +25,8 @@ namespace hst {
 
 class Process {
   public:
-    using Bag = std::unordered_multiset<const Process*>;
-    using Set = std::unordered_set<const Process*>;
+    class Bag;
+    class Set;
 
     virtual ~Process() = default;
 
@@ -90,21 +90,35 @@ operator<<(std::ostream& out, const Process& process)
     return out;
 }
 
-std::ostream& operator<<(std::ostream& out, const Process::Bag& processes);
+class Process::Bag : public std::unordered_multiset<const Process*> {
+  private:
+    using Parent = std::unordered_multiset<const Process*>;
+
+  public:
+    using Parent::unordered_multiset;
+
+    std::size_t hash() const;
+};
 
 bool
 operator==(const Process::Bag& lhs, const Process::Bag& rhs);
 
-std::size_t
-hash(const Process::Bag& set);
+std::ostream& operator<<(std::ostream& out, const Process::Bag& processes);
 
-std::ostream& operator<<(std::ostream& out, const Process::Set& processes);
+class Process::Set : public std::unordered_set<const Process*> {
+  private:
+    using Parent = std::unordered_set<const Process*>;
+
+  public:
+    using Parent::unordered_set;
+
+    std::size_t hash() const;
+};
 
 bool
 operator==(const Process::Set& lhs, const Process::Set& rhs);
 
-std::size_t
-hash(const Process::Set& set);
+std::ostream& operator<<(std::ostream& out, const Process::Set& processes);
 
 }  // namespace hst
 
@@ -122,9 +136,9 @@ struct hash<hst::Process>
 template <>
 struct hash<hst::Process::Bag>
 {
-    std::size_t operator()(const hst::Process::Bag& set) const
+    std::size_t operator()(const hst::Process::Bag& bag) const
     {
-        return hst::hash(set);
+        return bag.hash();
     }
 };
 
@@ -133,7 +147,7 @@ struct hash<hst::Process::Set>
 {
     std::size_t operator()(const hst::Process::Set& set) const
     {
-        return hst::hash(set);
+        return set.hash();
     }
 };
 

--- a/src/hst/sequential-composition.cc
+++ b/src/hst/sequential-composition.cc
@@ -59,7 +59,7 @@ Environment::sequential_composition(const Process* p, const Process* q)
 //       P;Q -τ→ Q
 
 void
-SequentialComposition::initials(std::set<Event>* out) const
+SequentialComposition::initials(Event::Set* out) const
 {
     // 1) P;Q can perform all of the same events as P, except for ✔.
     // 2) If P can perform ✔, then P;Q can perform τ.


### PR DESCRIPTION
Before we just had a `using` clause that declared nicer names for `std::unordered_set` and `_multiset` with the right template parameters.  By making these proper classes, we can add additional methods to them.