### PR TITLE
Calculate τ closures

### DIFF
--- a/src/hst/process.cc
+++ b/src/hst/process.cc
@@ -78,6 +78,24 @@ Process::Set::hash() const
     return hash.value();
 }
 
+void
+Process::Set::tau_close()
+{
+    Event tau = Event::tau();
+    while (true) {
+        Process::Set new_processes;
+        for (const Process* process : *this) {
+            process->afters(tau, &new_processes);
+        }
+        size_type old_size = size();
+        insert(new_processes.begin(), new_processes.end());
+        size_type new_size = size();
+        if (old_size == new_size) {
+            return;
+        }
+    }
+}
+
 bool
 operator==(const Process::Set& lhs, const Process::Set& rhs)
 {

--- a/src/hst/process.h
+++ b/src/hst/process.h
@@ -113,6 +113,10 @@ class Process::Set : public std::unordered_set<const Process*> {
     using Parent::unordered_set;
 
     std::size_t hash() const;
+
+    // Updates this set of processes to be τ-closed.  (That is, we add any
+    // additional processes you can reach by following τ one or more times.)
+    void tau_close();
 };
 
 bool

--- a/tests/test-operators.cc
+++ b/tests/test-operators.cc
@@ -111,6 +111,18 @@ check_reachable(const std::string& csp0,
     check_eq(actual, require_csp0_set(&env, expected));
 }
 
+// Verify the τ-closure of `process`.
+void
+check_tau_closure(const std::string& csp0,
+                  std::initializer_list<const std::string> expected)
+{
+    Environment env;
+    const Process* process = require_csp0(&env, csp0);
+    Process::Set actual{process};
+    actual.tau_close();
+    check_eq(actual, require_csp0_set(&env, expected));
+}
+
 }  // namespace
 
 TEST_CASE_GROUP("process comparisons");
@@ -152,6 +164,7 @@ TEST_CASE("STOP □ STOP")
     check_initials(p, {});
     check_afters(p, "a", {});
     check_reachable(p, {"STOP □ STOP"});
+    check_tau_closure(p, {"STOP □ STOP"});
 }
 
 TEST_CASE("(a → STOP) □ (b → STOP ⊓ c → STOP)")
@@ -164,6 +177,8 @@ TEST_CASE("(a → STOP) □ (b → STOP ⊓ c → STOP)")
     check_afters(p, "τ", {"a → STOP □ b → STOP", "a → STOP □ c → STOP"});
     check_reachable(p, {"(a → STOP) □ (b → STOP ⊓ c → STOP)",
                         "a → STOP □ b → STOP", "a → STOP □ c → STOP", "STOP"});
+    check_tau_closure(p, {"(a → STOP) □ (b → STOP ⊓ c → STOP)",
+                          "a → STOP □ b → STOP", "a → STOP □ c → STOP"});
 }
 
 TEST_CASE("(a → STOP) □ (b → STOP)")
@@ -175,6 +190,7 @@ TEST_CASE("(a → STOP) □ (b → STOP)")
     check_afters(p, "b", {"STOP"});
     check_afters(p, "τ", {});
     check_reachable(p, {"(a → STOP) □ (b → STOP)", "STOP"});
+    check_tau_closure(p, {"(a → STOP) □ (b → STOP)"});
 }
 
 TEST_CASE("□ {a → STOP, b → STOP, c → STOP}")
@@ -187,6 +203,7 @@ TEST_CASE("□ {a → STOP, b → STOP, c → STOP}")
     check_afters(p, "c", {"STOP"});
     check_afters(p, "τ", {});
     check_reachable(p, {"□ {a → STOP, b → STOP, c → STOP}", "STOP"});
+    check_tau_closure(p, {"□ {a → STOP, b → STOP, c → STOP}"});
 }
 
 TEST_CASE_GROUP("interleaving");
@@ -200,6 +217,7 @@ TEST_CASE("STOP ⫴ STOP")
     check_afters(p, "a", {});
     check_afters(p, "τ", {});
     check_reachable(p, {"STOP ⫴ STOP", "STOP"});
+    check_tau_closure(p, {"STOP ⫴ STOP"});
 }
 
 TEST_CASE("(a → STOP) ⫴ (b → STOP ⊓ c → STOP)")
@@ -215,6 +233,8 @@ TEST_CASE("(a → STOP) ⫴ (b → STOP ⊓ c → STOP)")
                 "STOP ⫴ (b → STOP ⊓ c → STOP)", "STOP ⫴ b → STOP",
                 "STOP ⫴ c → STOP", "a → STOP ⫴ b → STOP", "a → STOP ⫴ c → STOP",
                 "a → STOP ⫴ STOP", "STOP ⫴ STOP", "STOP"});
+    check_tau_closure(p, {"(a → STOP) ⫴ (b → STOP ⊓ c → STOP)",
+                          "a → STOP ⫴ b → STOP", "a → STOP ⫴ c → STOP"});
 }
 
 TEST_CASE("a → STOP ⫴ a → STOP")
@@ -227,6 +247,7 @@ TEST_CASE("a → STOP ⫴ a → STOP")
     check_afters(p, "τ", {});
     check_reachable(p, {"a → STOP ⫴ a → STOP", "a → STOP ⫴ STOP", "STOP ⫴ STOP",
                         "STOP"});
+    check_tau_closure(p, {"a → STOP ⫴ a → STOP"});
 }
 
 TEST_CASE("a → STOP ⫴ b → STOP")
@@ -239,6 +260,7 @@ TEST_CASE("a → STOP ⫴ b → STOP")
     check_afters(p, "τ", {});
     check_reachable(p, {"a → STOP ⫴ b → STOP", "a → STOP ⫴ STOP",
                         "STOP ⫴ b → STOP", "STOP ⫴ STOP", "STOP"});
+    check_tau_closure(p, {"a → STOP ⫴ b → STOP"});
 }
 
 TEST_CASE("a → SKIP ⫴ b → SKIP")
@@ -253,6 +275,7 @@ TEST_CASE("a → SKIP ⫴ b → SKIP")
     check_reachable(p, {"a → SKIP ⫴ b → SKIP", "a → SKIP ⫴ SKIP",
                         "a → SKIP ⫴ STOP", "SKIP ⫴ b → SKIP", "STOP ⫴ b → SKIP",
                         "STOP ⫴ SKIP", "STOP ⫴ STOP", "SKIP ⫴ SKIP", "STOP"});
+    check_tau_closure(p, {"a → SKIP ⫴ b → SKIP"});
 }
 
 TEST_CASE("(a → SKIP ⫴ b → SKIP) ; c → STOP")
@@ -269,6 +292,7 @@ TEST_CASE("(a → SKIP ⫴ b → SKIP) ; c → STOP")
                 "(SKIP ⫴ b → SKIP) ; c → STOP", "(STOP ⫴ b → SKIP) ; c → STOP",
                 "(STOP ⫴ SKIP) ; c → STOP", "(STOP ⫴ STOP) ; c → STOP",
                 "(SKIP ⫴ SKIP) ; c → STOP", "c → STOP", "STOP"});
+    check_tau_closure(p, {"(a → SKIP ⫴ b → SKIP) ; c → STOP"});
 }
 
 TEST_CASE("⫴ {a → STOP, b → STOP, c → STOP}")
@@ -286,6 +310,7 @@ TEST_CASE("⫴ {a → STOP, b → STOP, c → STOP}")
              "⫴ {STOP, a → STOP, c → STOP}", "⫴ {STOP, b → STOP, c → STOP}",
              "⫴ {STOP, STOP, a → STOP}", "⫴ {STOP, STOP, b → STOP}",
              "⫴ {STOP, STOP, c → STOP}", "⫴ {STOP, STOP, STOP}", "STOP"});
+    check_tau_closure(p, {"⫴ {a → STOP, b → STOP, c → STOP}"});
 }
 
 TEST_CASE_GROUP("internal choice");
@@ -298,6 +323,7 @@ TEST_CASE("STOP ⊓ STOP")
     check_afters(p, "τ", {"STOP"});
     check_afters(p, "a", {});
     check_reachable(p, {"STOP ⊓ STOP", "STOP"});
+    check_tau_closure(p, {"STOP ⊓ STOP", "STOP"});
 }
 
 TEST_CASE("(a → STOP) ⊓ (b → STOP)")
@@ -309,6 +335,7 @@ TEST_CASE("(a → STOP) ⊓ (b → STOP)")
     check_afters(p, "a", {});
     check_reachable(
             p, {"(a → STOP) ⊓ (b → STOP)", "a → STOP", "b → STOP", "STOP"});
+    check_tau_closure(p, {"(a → STOP) ⊓ (b → STOP)", "a → STOP", "b → STOP"});
 }
 
 TEST_CASE("⊓ {a → STOP, b → STOP, c → STOP}")
@@ -320,6 +347,8 @@ TEST_CASE("⊓ {a → STOP, b → STOP, c → STOP}")
     check_afters(p, "a", {});
     check_reachable(p, {"⊓ {a → STOP, b → STOP, c → STOP}", "a → STOP",
                         "b → STOP", "c → STOP", "STOP"});
+    check_tau_closure(p, {"⊓ {a → STOP, b → STOP, c → STOP}", "a → STOP",
+                          "b → STOP", "c → STOP"});
 }
 
 TEST_CASE_GROUP("prefix");
@@ -332,6 +361,7 @@ TEST_CASE("a → STOP")
     check_afters(p, "a", {"STOP"});
     check_afters(p, "τ", {});
     check_reachable(p, {"a → STOP", "STOP"});
+    check_tau_closure(p, {"a → STOP"});
 }
 
 TEST_CASE("a → b → STOP")
@@ -342,6 +372,7 @@ TEST_CASE("a → b → STOP")
     check_afters(p, "a", {"b → STOP"});
     check_afters(p, "τ", {});
     check_reachable(p, {"a → b → STOP", "b → STOP", "STOP"});
+    check_tau_closure(p, {"a → b → STOP"});
 }
 
 TEST_CASE_GROUP("SKIP");
@@ -355,6 +386,7 @@ TEST_CASE("SKIP")
     check_afters(skip, "τ", {});
     check_afters(skip, "✔", {"STOP"});
     check_reachable(skip, {"SKIP", "STOP"});
+    check_tau_closure(skip, {"SKIP"});
 }
 
 TEST_CASE_GROUP("STOP");
@@ -367,6 +399,7 @@ TEST_CASE("STOP")
     check_afters(stop, "a", {});
     check_afters(stop, "τ", {});
     check_reachable(stop, {"STOP"});
+    check_tau_closure(stop, {"STOP"});
 }
 
 TEST_CASE_GROUP("sequential composition");
@@ -381,6 +414,7 @@ TEST_CASE("SKIP ; STOP")
     check_afters(p, "τ", {"STOP"});
     check_afters(p, "✔", {});
     check_reachable(p, {"SKIP ; STOP", "STOP"});
+    check_tau_closure(p, {"SKIP ; STOP", "STOP"});
 }
 
 TEST_CASE("a → SKIP ; STOP")
@@ -393,6 +427,7 @@ TEST_CASE("a → SKIP ; STOP")
     check_afters(p, "τ", {});
     check_afters(p, "✔", {});
     check_reachable(p, {"a → SKIP ; STOP", "SKIP ; STOP", "STOP"});
+    check_tau_closure(p, {"a → SKIP ; STOP"});
 }
 
 TEST_CASE("(a → b → STOP □ SKIP) ; STOP")
@@ -406,6 +441,7 @@ TEST_CASE("(a → b → STOP □ SKIP) ; STOP")
     check_afters(p, "✔", {});
     check_reachable(p, {"(a → b → STOP □ SKIP) ; STOP", "b → STOP ; STOP",
                         "STOP ; STOP", "STOP"});
+    check_tau_closure(p, {"(a → b → STOP □ SKIP) ; STOP", "STOP"});
 }
 
 TEST_CASE("(a → b → STOP ⊓ SKIP) ; STOP")
@@ -420,4 +456,6 @@ TEST_CASE("(a → b → STOP ⊓ SKIP) ; STOP")
     check_reachable(p,
                     {"(a → b → STOP ⊓ SKIP) ; STOP", "a → b → STOP ; STOP",
                      "SKIP ; STOP", "b → STOP ; STOP", "STOP ; STOP", "STOP"});
+    check_tau_closure(p, {"(a → b → STOP ⊓ SKIP) ; STOP", "a → b → STOP ; STOP",
+                          "SKIP ; STOP", "STOP"});
 }


### PR DESCRIPTION
We'll need to calculate these a lot during normalization and refinement.  This is similar to the operation that translates an NFA into a DFA when working with regular expressions.  Given a set of processes, we need to extend that set with any additional processes that you could get to by only following hidden events (which are called τ in CSP).