### PR TITLE
Add prenormalized processes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,7 @@ libhst_la_SOURCES = \
 	src/hst/interleave.cc \
 	src/hst/internal-choice.cc \
 	src/hst/prefix.cc \
+	src/hst/prenormalize.cc \
 	src/hst/process.h \
 	src/hst/process.cc \
 	src/hst/sequential-composition.cc

--- a/src/hst/csp0.cc
+++ b/src/hst/csp0.cc
@@ -701,13 +701,35 @@ class Process11 : public Parser {
     }
 };
 
+#define Process12 Process11  // NIY
+
+class Process13 : public Parser {
+  public:
+    Process13(Parser* parent, hst::Environment* env, const hst::Process** out)
+        : Parser(parent, "process13")
+    {
+        // process13 = process12 | prenormalize {process}
+
+        // prenormalize {process}
+        if (attempt<RequireString>("prenormalize")) {
+            return_if_error(attempt<SkipWhitespace>());
+            hst::Process::Set processes;
+            return_if_error(attempt<ProcessSet>(env, &processes));
+            *out = env->prenormalize(std::move(processes));
+            return;
+        }
+
+        return_if_error(attempt<Process12>(env, out));
+    }
+};
+
 // Now that we have all of our per-level Parsers defined, we just have to
 // delegate to the top level of the precedence tree to parse a Process.
 Process::Process(Parser* parent, hst::Environment* env,
                  const hst::Process** out)
     : Parser(parent, "process")
 {
-    return_if_error(attempt<Process11>(env, out));
+    return_if_error(attempt<Process13>(env, out));
 }
 
 }  // namespace

--- a/src/hst/environment.cc
+++ b/src/hst/environment.cc
@@ -130,4 +130,11 @@ Environment::register_process(std::unique_ptr<Process> process)
     return result.first->get();
 }
 
+const NormalizedProcess*
+Environment::register_process(std::unique_ptr<NormalizedProcess> process)
+{
+    auto result = registry_.insert(std::move(process));
+    return static_cast<const NormalizedProcess*>(result.first->get());
+}
+
 }  // namespace hst

--- a/src/hst/environment.h
+++ b/src/hst/environment.h
@@ -29,6 +29,8 @@ class Environment {
     const Process* sequential_composition(const Process* p, const Process* q);
     const Process* skip() const { return skip_; }
     const Process* stop() const { return stop_; }
+    const NormalizedProcess* prenormalize(const Process* p);
+    const NormalizedProcess* prenormalize(Process::Set ps);
 
   private:
     struct deref_hash {
@@ -52,6 +54,8 @@ class Environment {
     // Ensures that there is exactly one process in the registry equal to
     // `process`, returning a pointer to that process.
     const Process* register_process(std::unique_ptr<Process> process);
+    const NormalizedProcess*
+    register_process(std::unique_ptr<NormalizedProcess> process);
 
     Registry registry_;
     const Process* skip_;

--- a/src/hst/prenormalize.cc
+++ b/src/hst/prenormalize.cc
@@ -1,0 +1,111 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#include "hst/environment.h"
+
+#include <memory>
+#include <ostream>
+
+#include "hst/event.h"
+#include "hst/hash.h"
+#include "hst/process.h"
+
+namespace hst {
+
+namespace {
+
+class Prenormalization : public NormalizedProcess {
+  public:
+    Prenormalization(Environment* env, Process::Set ps) : env_(env), ps_(ps)
+    {
+        ps_.tau_close();
+    }
+
+    void initials(Event::Set* out) const override;
+    const NormalizedProcess* after(Event initial) const override;
+
+    std::size_t hash() const override;
+    bool operator==(const Process& other) const override;
+    unsigned int precedence() const override { return 0; }
+    void print(std::ostream& out) const override;
+
+  private:
+    Environment* env_;
+    Process::Set ps_;  // constructor ensures this is τ-closed
+};
+
+}  // namespace
+
+const NormalizedProcess*
+Environment::prenormalize(Process::Set ps)
+{
+    return register_process(std::unique_ptr<NormalizedProcess>(
+            new Prenormalization(this, std::move(ps))));
+}
+
+const NormalizedProcess*
+Environment::prenormalize(const Process* p)
+{
+    return prenormalize(Process::Set{p});
+}
+
+void
+Prenormalization::initials(Event::Set* out) const
+{
+    // Find all of the non-τ events that any of the underlying processes can
+    // perform.
+    for (const Process* p : ps_) {
+        p->initials(out);
+    }
+    out->erase(Event::tau());
+}
+
+const NormalizedProcess*
+Prenormalization::after(Event initial) const
+{
+    // Prenormalized processes can never perform a τ.
+    if (initial == Event::tau()) {
+        return nullptr;
+    }
+
+    // Find the set of processes that you could end up in by starting in one of
+    // our underlying processes and following a single `initial` event.
+    Process::Set afters;
+    for (const Process* p : ps_) {
+        p->afters(initial, &afters);
+    }
+
+    // Since a normalized process can only have one `after` for any event, merge
+    // together all of the possible afters into a single prenormalized process.
+    return env_->prenormalize(std::move(afters));
+}
+
+std::size_t
+Prenormalization::hash() const
+{
+    static hash_scope prenormalized;
+    return hasher(prenormalized).add(ps_).value();
+}
+
+bool
+Prenormalization::operator==(const Process& other_) const
+{
+    const Prenormalization* other =
+            dynamic_cast<const Prenormalization*>(&other_);
+    if (other == nullptr) {
+        return false;
+    }
+    return ps_ == other->ps_;
+}
+
+void
+Prenormalization::print(std::ostream& out) const
+{
+    out << "prenormalize " << ps_;
+}
+
+}  // namespace hst

--- a/src/hst/process.cc
+++ b/src/hst/process.cc
@@ -17,6 +17,15 @@
 
 namespace hst {
 
+void
+NormalizedProcess::afters(Event initial, Set* out) const
+{
+    const NormalizedProcess* process = after(initial);
+    if (process) {
+        out->insert(process);
+    }
+}
+
 std::size_t
 Process::Bag::hash() const
 {

--- a/src/hst/process.h
+++ b/src/hst/process.h
@@ -90,6 +90,12 @@ operator<<(std::ostream& out, const Process& process)
     return out;
 }
 
+class NormalizedProcess : public Process {
+  public:
+    virtual const NormalizedProcess* after(Event initial) const = 0;
+    void afters(Event initial, Set* out) const final;
+};
+
 class Process::Bag : public std::unordered_multiset<const Process*> {
   private:
     using Parent = std::unordered_multiset<const Process*>;

--- a/tests/test-operators.cc
+++ b/tests/test-operators.cc
@@ -459,3 +459,68 @@ TEST_CASE("(a → b → STOP ⊓ SKIP) ; STOP")
     check_tau_closure(p, {"(a → b → STOP ⊓ SKIP) ; STOP", "a → b → STOP ; STOP",
                           "SKIP ; STOP", "STOP"});
 }
+
+TEST_CASE_GROUP("prenormalization");
+
+TEST_CASE("prenormalize {a → STOP}")
+{
+    auto p = "prenormalize {a → STOP}";
+    check_name(p, "prenormalize {a → STOP}");
+    check_initials(p, {"a"});
+    check_afters(p, "a", {"prenormalize {STOP}"});
+    check_afters(p, "τ", {});
+    check_reachable(p, {"prenormalize {a → STOP}", "prenormalize {STOP}"});
+    check_tau_closure(p, {"prenormalize {a → STOP}"});
+}
+
+TEST_CASE("prenormalize {a → STOP □ b → STOP}")
+{
+    auto p = "prenormalize {a → STOP □ b → STOP}";
+    check_name(p, "prenormalize {a → STOP □ b → STOP}");
+    check_initials(p, {"a", "b"});
+    check_afters(p, "a", {"prenormalize {STOP}"});
+    check_afters(p, "b", {"prenormalize {STOP}"});
+    check_afters(p, "τ", {});
+    check_reachable(
+            p, {"prenormalize {a → STOP □ b → STOP}", "prenormalize {STOP}"});
+    check_tau_closure(p, {"prenormalize {a → STOP □ b → STOP}"});
+}
+
+TEST_CASE("prenormalize {a → STOP □ a → b → STOP}")
+{
+    auto p = "prenormalize {a → STOP □ a → b → STOP}";
+    check_name(p, "prenormalize {a → STOP □ a → b → STOP}");
+    check_initials(p, {"a"});
+    check_afters(p, "a", {"prenormalize {STOP, b → STOP}"});
+    check_afters(p, "τ", {});
+    check_reachable(p,
+                    {"prenormalize {a → STOP □ a → b → STOP}",
+                     "prenormalize {STOP, b → STOP}", "prenormalize {STOP}"});
+    check_tau_closure(p, {"prenormalize {a → STOP □ a → b → STOP}"});
+}
+
+TEST_CASE("prenormalize {a → STOP ⊓ b → STOP}")
+{
+    auto p = "prenormalize {a → STOP ⊓ b → STOP}";
+    check_name(p, "prenormalize {a → STOP, a → STOP ⊓ b → STOP, b → STOP}");
+    check_initials(p, {"a", "b"});
+    check_afters(p, "a", {"prenormalize {STOP}"});
+    check_afters(p, "b", {"prenormalize {STOP}"});
+    check_afters(p, "τ", {});
+    check_reachable(
+            p, {"prenormalize {a → STOP ⊓ b → STOP}", "prenormalize {STOP}"});
+    check_tau_closure(p, {"prenormalize {a → STOP ⊓ b → STOP}"});
+}
+
+TEST_CASE("prenormalize {a → SKIP ; b → STOP}")
+{
+    auto p = "prenormalize {a → SKIP ; b → STOP}";
+    check_name(p, "prenormalize {a → SKIP ; b → STOP}");
+    check_initials(p, {"a"});
+    check_afters(p, "a", {"prenormalize {SKIP ; b → STOP}"});
+    check_afters(p, "τ", {});
+    check_reachable(p,
+                    {"prenormalize {a → SKIP ; b → STOP}",
+                     "prenormalize {SKIP ; b → STOP}", "prenormalize {STOP}"});
+    check_tau_closure(p, {"prenormalize {a → SKIP ; b → STOP}"});
+}


### PR DESCRIPTION
This is the first step in a refinement check.  It's equivalent to transforming an NFA to a DFA when working with regular expressions.  Instead of our LTS graph nodes representing individual processes, each node represents a set of processes; we merge together all of the states that are reachable by following only hidden τ events; after having followed a particular trace of visible events, you might be an any of those states.

We implement this using the same Process interface as our "normal" CSP operators; the only difference is that we guarantee that `initials` will never return τ, and that `afters` will never return more than one
outgoing process for any event.