### PR TITLE
Add traces behavior

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,8 @@ libhst_la_SOURCES = \
 	src/hst/prenormalize.cc \
 	src/hst/process.h \
 	src/hst/process.cc \
+	src/hst/semantic-models.h \
+	src/hst/semantic-models.cc \
 	src/hst/sequential-composition.cc
 
 hst_SOURCES = \

--- a/src/hst/semantic-models.cc
+++ b/src/hst/semantic-models.cc
@@ -1,0 +1,35 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#include "hst/semantic-models.h"
+
+#include "hst/event.h"
+#include "hst/process.h"
+
+namespace hst {
+
+Traces::Behavior
+Traces::get_process_behavior(const Process& process)
+{
+    Traces::Behavior result;
+    process.initials(&result);
+    result.erase(Event::tau());
+    return result;
+}
+
+Traces::Behavior
+Traces::get_process_behavior(const Process::Set& processes)
+{
+    Traces::Behavior result;
+    for (const Process* process : processes) {
+        process->initials(&result);
+    }
+    result.erase(Event::tau());
+    return result;
+}
+
+}  // namespace hst

--- a/src/hst/semantic-models.h
+++ b/src/hst/semantic-models.h
@@ -1,0 +1,37 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef HST_SEMANTIC_MODELS_H
+#define HST_SEMANTIC_MODELS_H
+
+#include "hst/event.h"
+#include "hst/process.h"
+
+namespace hst {
+
+#if 0
+// Each semantic model is defined by a struct that must implement the following
+// signature:
+struct SemanticModel {
+    class Behavior;
+    static Behavior get_process_behavior(const Process& process);
+    static Behavior get_process_behavior(const Process::Set& processes);
+};
+#endif
+
+struct Traces {
+    // In the traces model, the behavior of a process is the set of non-τ events
+    // that it can perform.
+    using Behavior = Event::Set;
+
+    static Behavior get_process_behavior(const Process& process);
+    static Behavior get_process_behavior(const Process::Set& processes);
+};
+
+}  // namespace hst
+
+#endif  // HST_SEMANTIC_MODELS_H


### PR DESCRIPTION
This is the first semantic model that we want to support.  Each semantic model will have its own wrapper struct, containing all of the classes and methods that define that method.  That will let us parameterize certain bits of the refinement checker in a nicely generic way.

In the traces model, the behavior of a process is the set of non-τ events that it can perform.  That's easy enough to calculate, just by calling the process's `initials` method.