### PR TITLE
Return specific type when registering a process

### DIFF
--- a/src/hst/environment.cc
+++ b/src/hst/environment.cc
@@ -119,22 +119,8 @@ Stop::print(std::ostream& out) const
 
 Environment::Environment()
 {
-    stop_ = register_process(std::unique_ptr<Process>(new Stop));
-    skip_ = register_process(std::unique_ptr<Process>(new Skip(stop_)));
-}
-
-const Process*
-Environment::register_process(std::unique_ptr<Process> process)
-{
-    auto result = registry_.insert(std::move(process));
-    return result.first->get();
-}
-
-const NormalizedProcess*
-Environment::register_process(std::unique_ptr<NormalizedProcess> process)
-{
-    auto result = registry_.insert(std::move(process));
-    return static_cast<const NormalizedProcess*>(result.first->get());
+    stop_ = register_process(new Stop);
+    skip_ = register_process(new Skip(stop_));
 }
 
 }  // namespace hst

--- a/src/hst/external-choice.cc
+++ b/src/hst/external-choice.cc
@@ -43,8 +43,7 @@ class ExternalChoice : public Process {
 const Process*
 Environment::external_choice(Process::Set ps)
 {
-    return register_process(
-            std::unique_ptr<Process>(new ExternalChoice(this, std::move(ps))));
+    return register_process(new ExternalChoice(this, std::move(ps)));
 }
 
 const Process*

--- a/src/hst/interleave.cc
+++ b/src/hst/interleave.cc
@@ -46,8 +46,7 @@ class Interleave : public Process {
 const Process*
 Environment::interleave(Process::Bag ps)
 {
-    return register_process(
-            std::unique_ptr<Process>(new Interleave(this, std::move(ps))));
+    return register_process(new Interleave(this, std::move(ps)));
 }
 
 const Process*

--- a/src/hst/internal-choice.cc
+++ b/src/hst/internal-choice.cc
@@ -38,8 +38,7 @@ class InternalChoice : public Process {
 const Process*
 Environment::internal_choice(Process::Set ps)
 {
-    return register_process(
-            std::unique_ptr<Process>(new InternalChoice(std::move(ps))));
+    return register_process(new InternalChoice(std::move(ps)));
 }
 
 const Process*

--- a/src/hst/prefix.cc
+++ b/src/hst/prefix.cc
@@ -39,7 +39,7 @@ class Prefix : public Process {
 const Process*
 Environment::prefix(Event a, const Process* p)
 {
-    return register_process(std::unique_ptr<Process>(new Prefix(a, p)));
+    return register_process(new Prefix(a, p));
 }
 
 // Operational semantics for a → P

--- a/src/hst/prenormalize.cc
+++ b/src/hst/prenormalize.cc
@@ -44,8 +44,7 @@ class Prenormalization : public NormalizedProcess {
 const NormalizedProcess*
 Environment::prenormalize(Process::Set ps)
 {
-    return register_process(std::unique_ptr<NormalizedProcess>(
-            new Prenormalization(this, std::move(ps))));
+    return register_process(new Prenormalization(this, std::move(ps)));
 }
 
 const NormalizedProcess*

--- a/src/hst/sequential-composition.cc
+++ b/src/hst/sequential-composition.cc
@@ -44,8 +44,7 @@ class SequentialComposition : public Process {
 const Process*
 Environment::sequential_composition(const Process* p, const Process* q)
 {
-    return register_process(
-            std::unique_ptr<Process>(new SequentialComposition(this, p, q)));
+    return register_process(new SequentialComposition(this, p, q));
 }
 
 // Operational semantics for P ; Q


### PR DESCRIPTION
The method that registers a process in an environment is now templated, and no longer upcasts the return value to the Process supertype.  When you register a specific subclass, you get that same specific subclass as your result.