### PR TITLE
Add recursive processes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,8 @@ libhst_la_SOURCES = \
 	src/hst/prenormalize.cc \
 	src/hst/process.h \
 	src/hst/process.cc \
+	src/hst/recursion.h \
+	src/hst/recursion.cc \
 	src/hst/semantic-models.h \
 	src/hst/semantic-models.cc \
 	src/hst/sequential-composition.cc

--- a/src/hst/environment.h
+++ b/src/hst/environment.h
@@ -12,6 +12,7 @@
 
 #include "hst/event.h"
 #include "hst/process.h"
+#include "hst/recursion.h"
 
 namespace hst {
 
@@ -26,10 +27,15 @@ class Environment {
     const Process* internal_choice(const Process* p, const Process* q);
     const Process* internal_choice(Process::Set ps);
     const Process* prefix(Event a, const Process* p);
+    RecursionScope recursion();
     const Process* sequential_composition(const Process* p, const Process* q);
     const Process* skip() const { return skip_; }
     const Process* stop() const { return stop_; }
     const NormalizedProcess* prenormalize(const Process* p);
+
+    // These will typically only be used internally or in test cases.
+    RecursiveProcess*
+    recursive_process(RecursionScope::ID scope, const std::string& name);
     const NormalizedProcess* prenormalize(Process::Set ps);
 
     // Ensures that there is exactly one process in the registry equal to
@@ -59,6 +65,7 @@ class Environment {
     Registry registry_;
     const Process* skip_;
     const Process* stop_;
+    RecursionScope::ID next_recursion_scope_ = 0;
 };
 
 template <typename T>

--- a/src/hst/recursion.cc
+++ b/src/hst/recursion.cc
@@ -1,0 +1,101 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#include "hst/recursion.h"
+
+#include <assert.h>
+#include <string>
+#include <unordered_map>
+
+#include "hst/environment.h"
+#include "hst/event.h"
+#include "hst/hash.h"
+#include "hst/process.h"
+
+namespace hst {
+
+RecursionScope
+Environment::recursion()
+{
+    return RecursionScope(this, next_recursion_scope_++);
+}
+
+RecursiveProcess*
+RecursionScope::add(std::string name)
+{
+    RecursiveProcess*& process = processes_[name];
+    if (!process) {
+        process = env_->recursive_process(id_, std::move(name));
+    }
+    return process;
+}
+
+void
+RecursionScope::unfilled_processes(std::vector<const std::string*>* names) const
+{
+    for (const auto& name_and_process : processes_) {
+        RecursiveProcess* process = name_and_process.second;
+        if (!process->filled()) {
+            names->push_back(&process->name());
+        }
+    }
+}
+
+RecursiveProcess*
+Environment::recursive_process(RecursionScope::ID scope,
+                               const std::string& name)
+{
+    return register_process(new RecursiveProcess(this, scope, std::move(name)));
+}
+
+void
+RecursiveProcess::initials(Event::Set* out) const
+{
+    assert(filled());
+    target_->initials(out);
+}
+
+void
+RecursiveProcess::afters(Event initial, Process::Set* out) const
+{
+    assert(filled());
+    target_->afters(initial, out);
+}
+
+std::size_t
+RecursiveProcess::hash() const
+{
+    static hash_scope recursion;
+    return hasher(recursion).add(env_).add(scope_).add(name_).value();
+}
+
+bool
+RecursiveProcess::operator==(const Process& other_) const
+{
+    const RecursiveProcess* other =
+            dynamic_cast<const RecursiveProcess*>(&other_);
+    if (other == nullptr) {
+        return false;
+    }
+    return env_ == other->env_ && scope_ == other->scope_ &&
+           name_ == other->name_;
+}
+
+void
+RecursiveProcess::print(std::ostream& out) const
+{
+    out << "whomp";
+}
+
+void
+RecursiveProcess::fill(const Process* target)
+{
+    assert(!filled());
+    target_ = target;
+}
+
+}  // namespace hst

--- a/src/hst/recursion.h
+++ b/src/hst/recursion.h
@@ -1,0 +1,76 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef HST_RECURSION_H
+#define HST_RECURSION_H
+
+#include <string>
+#include <unordered_map>
+
+#include "hst/event.h"
+#include "hst/process.h"
+
+namespace hst {
+
+class Environment;
+class RecursiveProcess;
+
+// A "recursion scope" is the main building block that you need to create
+// mutually recursive processes.  You can create one or more "recursion targets"
+// within the scope, each of which maps a name to a process.  But importantly,
+// you don't have to know in advance which process you're going to map each name
+// to.  That lets you define a name for a process, and then use that same name
+// in the definition of the process.  Presto, recursion!
+class RecursionScope {
+  public:
+    using ID = unsigned int;
+
+    explicit RecursionScope(Environment* env, ID id) : env_(env), id_(id) {}
+    RecursiveProcess* add(std::string name);
+
+    // Returns the names of any recursive processes in this scope that haven't
+    // been filled.
+    void unfilled_processes(std::vector<const std::string*>* names) const;
+
+  private:
+    using ProcessMap = std::unordered_map<std::string, RecursiveProcess*>;
+    Environment* env_;
+    ID id_;
+    ProcessMap processes_;
+};
+
+class RecursiveProcess : public Process {
+  public:
+    explicit RecursiveProcess(Environment* env, RecursionScope::ID scope,
+                              std::string name)
+        : env_(env), scope_(scope), name_(std::move(name)), target_(nullptr)
+    {
+    }
+
+    void initials(Event::Set* out) const override;
+    void afters(Event initial, Process::Set* out) const override;
+
+    const std::string& name() const { return name_; }
+    bool filled() const { return target_; }
+    std::size_t hash() const override;
+    bool operator==(const Process& other) const override;
+    unsigned int precedence() const override { return 0; }
+    void print(std::ostream& out) const override;
+
+    // Fills this recursive process with a target, which must not have already
+    // been filed.
+    void fill(const Process* target);
+
+  private:
+    Environment* env_;
+    RecursionScope::ID scope_;
+    std::string name_;
+    const Process* target_;
+};
+
+}  // namespace hst
+#endif  // HST_RECURSION_H

--- a/tests/test-csp0.cc
+++ b/tests/test-csp0.cc
@@ -87,6 +87,16 @@ TEST_CASE("can parse identifiers")
     check_csp0_invalid("$ → STOP");
 }
 
+TEST_CASE("can parse debug recursion identifiers")
+{
+    // Parse a bunch of valid identifiers.
+    check_csp0_valid("let X = a → STOP within X@0");
+    check_csp0_valid("let X = let Y = a → STOP within X@1 within STOP");
+    // Fail to parse a bunch of invalid identifiers.
+    check_csp0_invalid("let X = a → STOP within X@");
+    check_csp0_invalid("let X = a → STOP within X@X");
+}
+
 TEST_CASE_GROUP("CSP₀ primitives");
 
 TEST_CASE("parse: STOP")
@@ -397,6 +407,39 @@ TEST_CASE("parse: a → SKIP ; STOP")
     check_csp0_invalid("SKIP;");
     check_csp0_invalid("SKIP ;");
     check_csp0_invalid("SKIP ; ");
+}
+
+TEST_CASE("parse: let X = a → STOP within X")
+{
+    // Verify that we can parse the process, with and without whitespace.
+    check_csp0_valid("let X=a→STOP within X");
+    check_csp0_valid(" let X=a→STOP within X");
+    check_csp0_valid(" let X =a→STOP within X");
+    check_csp0_valid(" let X = a→STOP within X");
+    check_csp0_valid(" let X = a →STOP within X");
+    check_csp0_valid(" let X = a → STOP within X");
+    check_csp0_valid(" let X = a → STOP within X ");
+    // Fail to parse a bunch of invalid statements.
+    // missing process definition
+    check_csp0_invalid("let within X");
+    // undefined process
+    check_csp0_invalid("let X = a → Y within X");
+}
+
+TEST_CASE("parse: let X = a → Y Y = b → X within X")
+{
+    // Verify that we can parse the process, with and without whitespace.
+    check_csp0_valid("let X=a→Y Y=b→X within X");
+    check_csp0_valid(" let X=a→Y Y=b→X within X");
+    check_csp0_valid(" let X =a→Y Y=b→X within X");
+    check_csp0_valid(" let X = a→Y Y=b→X within X");
+    check_csp0_valid(" let X = a →Y Y=b→X within X");
+    check_csp0_valid(" let X = a → Y Y=b→X within X");
+    check_csp0_valid(" let X = a → Y Y =b→X within X");
+    check_csp0_valid(" let X = a → Y Y = b→X within X");
+    check_csp0_valid(" let X = a → Y Y = b →X within X");
+    check_csp0_valid(" let X = a → Y Y = b → X within X");
+    check_csp0_valid(" let X = a → Y Y = b → X within X ");
 }
 
 TEST_CASE("associativity: a → SKIP ; b → SKIP ; c → SKIP")

--- a/tests/test-operators.cc
+++ b/tests/test-operators.cc
@@ -421,6 +421,30 @@ TEST_CASE("a → b → STOP")
     check_traces_behavior(p, {"a"});
 }
 
+TEST_CASE_GROUP("recursion");
+
+TEST_CASE("let X=a → STOP within X")
+{
+    auto p = "let X=a → STOP within X";
+    check_name(p, "whomp");  //"let X=a → STOP within X");
+    check_initials(p, {"a"});
+    check_afters(p, "a", {"STOP"});
+    check_reachable(p, {"X@0", "STOP"});
+    check_tau_closure(p, {"X@0"});
+    check_traces_behavior(p, {"a"});
+}
+
+TEST_CASE("let X=a → Y Y=b → X within X")
+{
+    auto p = "let X=a → Y Y=b → X within X";
+    check_name(p, "whomp");  //"let X=a → Y Y=b → X within X");
+    check_initials(p, {"a"});
+    check_afters(p, "a", {"Y@0"});
+    check_reachable(p, {"X@0", "Y@0"});
+    check_tau_closure(p, {"X@0"});
+    check_traces_behavior(p, {"a"});
+}
+
 TEST_CASE_GROUP("SKIP");
 
 TEST_CASE("SKIP")


### PR DESCRIPTION
Each `let` statement produces its own RecursionScope object at the code level.  Once we've finished parsing the `let` statement the scope object goes away, and the resulting RecursiveProcess objects stick around.