### PR TITLE
Add accessor for process's syntactic subprocesses

### DIFF
--- a/src/hst/environment.cc
+++ b/src/hst/environment.cc
@@ -18,6 +18,7 @@ class Skip : public Process {
     explicit Skip(const Process* stop) : stop_(stop) {}
     void initials(Event::Set* out) const override;
     void afters(Event initial, Process::Set* out) const override;
+    void subprocesses(Process::Set* out) const override;
 
     std::size_t hash() const override;
     bool operator==(const Process& other) const override;
@@ -42,6 +43,11 @@ Skip::afters(Event initial, Process::Set* out) const
     if (initial == Event::tick()) {
         out->insert(stop_);
     }
+}
+
+void
+Skip::subprocesses(Process::Set* out) const
+{
 }
 
 std::size_t
@@ -75,6 +81,7 @@ class Stop : public Process {
 
     void initials(Event::Set* out) const override;
     void afters(Event initial, Process::Set* out) const override;
+    void subprocesses(Process::Set* out) const override;
 
     std::size_t hash() const override;
     bool operator==(const Process& other) const override;
@@ -91,6 +98,11 @@ Stop::initials(Event::Set* out) const
 
 void
 Stop::afters(Event initial, Process::Set* out) const
+{
+}
+
+void
+Stop::subprocesses(Process::Set* out) const
 {
 }
 

--- a/src/hst/external-choice.cc
+++ b/src/hst/external-choice.cc
@@ -27,6 +27,7 @@ class ExternalChoice : public Process {
 
     void initials(Event::Set* out) const override;
     void afters(Event initial, Process::Set* out) const override;
+    void subprocesses(Process::Set* out) const override;
 
     std::size_t hash() const override;
     bool operator==(const Process& other) const override;
@@ -111,6 +112,12 @@ ExternalChoice::afters(Event initial, Process::Set* out) const
             p->afters(initial, out);
         }
     }
+}
+
+void
+ExternalChoice::subprocesses(Process::Set* out) const
+{
+    out->insert(ps_.begin(), ps_.end());
 }
 
 std::size_t

--- a/src/hst/interleave.cc
+++ b/src/hst/interleave.cc
@@ -26,6 +26,7 @@ class Interleave : public Process {
 
     void initials(Event::Set* out) const override;
     void afters(Event initial, Process::Set* out) const override;
+    void subprocesses(Process::Set* out) const override;
 
     std::size_t hash() const override;
     bool operator==(const Process& other) const override;
@@ -180,6 +181,12 @@ Interleave::afters(Event initial, Process::Set* out) const
     } else {
         normal_afters(initial, out);
     }
+}
+
+void
+Interleave::subprocesses(Process::Set* out) const
+{
+    out->insert(ps_.begin(), ps_.end());
 }
 
 std::size_t

--- a/src/hst/internal-choice.cc
+++ b/src/hst/internal-choice.cc
@@ -23,6 +23,7 @@ class InternalChoice : public Process {
     explicit InternalChoice(Process::Set ps) : ps_(std::move(ps)) {}
     void initials(Event::Set* out) const override;
     void afters(Event initial, Process::Set* out) const override;
+    void subprocesses(Process::Set* out) const override;
 
     std::size_t hash() const override;
     bool operator==(const Process& other) const override;
@@ -66,6 +67,12 @@ InternalChoice::afters(Event initial, Process::Set* out) const
     if (initial == Event::tau()) {
         out->insert(ps_.begin(), ps_.end());
     }
+}
+
+void
+InternalChoice::subprocesses(Process::Set* out) const
+{
+    out->insert(ps_.begin(), ps_.end());
 }
 
 std::size_t

--- a/src/hst/prefix.cc
+++ b/src/hst/prefix.cc
@@ -23,6 +23,7 @@ class Prefix : public Process {
     Prefix(Event a, const Process* p) : a_(a), p_(p) {}
     void initials(Event::Set* out) const override;
     void afters(Event initial, Process::Set* out) const override;
+    void subprocesses(Process::Set* out) const override;
 
     std::size_t hash() const override;
     bool operator==(const Process& other) const override;
@@ -61,6 +62,12 @@ Prefix::afters(Event initial, Process::Set* out) const
     if (initial == a_) {
         out->insert(p_);
     }
+}
+
+void
+Prefix::subprocesses(Process::Set* out) const
+{
+    out->insert(p_);
 }
 
 std::size_t

--- a/src/hst/prenormalize.cc
+++ b/src/hst/prenormalize.cc
@@ -27,6 +27,7 @@ class Prenormalization : public NormalizedProcess {
 
     void initials(Event::Set* out) const override;
     const NormalizedProcess* after(Event initial) const override;
+    void subprocesses(Process::Set* out) const override;
     void expand(Process::Set* out) const override;
 
     std::size_t hash() const override;
@@ -82,6 +83,12 @@ Prenormalization::after(Event initial) const
     // Since a normalized process can only have one `after` for any event, merge
     // together all of the possible afters into a single prenormalized process.
     return env_->prenormalize(std::move(afters));
+}
+
+void
+Prenormalization::subprocesses(Process::Set* out) const
+{
+    out->insert(ps_.begin(), ps_.end());
 }
 
 void

--- a/src/hst/process.h
+++ b/src/hst/process.h
@@ -32,12 +32,17 @@ class Process {
 
     Index index() const { return index_; }
 
-    // Fill `out` with the initial events of this process.
+    // Fills `out` with the initial events of this process.
     virtual void initials(Event::Set* out) const = 0;
 
-    // Fill `out` with the subprocesses that you reach after following a single
+    // Fills `out` with the subprocesses that you reach after following a single
     // `initial` event from this process.
     virtual void afters(Event initial, Set* out) const = 0;
+
+    // Fills `out` with the syntactic subprocesses of this process.  This should
+    // only include the subprocesses that are needed to print out the definition
+    // of this process.
+    virtual void subprocesses(Set* out) const = 0;
 
     // Calls op for each of the process's outgoing transitions.  op must have a
     // signature compatible with:

--- a/src/hst/recursion.cc
+++ b/src/hst/recursion.cc
@@ -68,6 +68,13 @@ RecursiveProcess::afters(Event initial, Process::Set* out) const
     definition_->afters(initial, out);
 }
 
+void
+RecursiveProcess::subprocesses(Process::Set* out) const
+{
+    assert(filled());
+    out->insert(definition_);
+}
+
 std::size_t
 RecursiveProcess::hash() const
 {

--- a/src/hst/recursion.h
+++ b/src/hst/recursion.h
@@ -53,6 +53,7 @@ class RecursiveProcess : public Process {
 
     void initials(Event::Set* out) const override;
     void afters(Event initial, Process::Set* out) const override;
+    void subprocesses(Process::Set* out) const override;
 
     const std::string& name() const { return name_; }
     const Process* definition() const { return definition_; }

--- a/src/hst/sequential-composition.cc
+++ b/src/hst/sequential-composition.cc
@@ -27,6 +27,7 @@ class SequentialComposition : public Process {
 
     void initials(Event::Set* out) const override;
     void afters(Event initial, Process::Set* out) const override;
+    void subprocesses(Process::Set* out) const override;
 
     std::size_t hash() const override;
     bool operator==(const Process& other) const override;
@@ -108,6 +109,13 @@ SequentialComposition::afters(Event initial, Process::Set* out) const
             out->insert(q_);
         }
     }
+}
+
+void
+SequentialComposition::subprocesses(Process::Set* out) const
+{
+    out->insert(p_);
+    out->insert(q_);
 }
 
 std::size_t

--- a/tests/test-operators.cc
+++ b/tests/test-operators.cc
@@ -79,6 +79,17 @@ check_name(const std::string& csp0, const std::string& expected)
 }
 
 void
+check_subprocesses(const std::string& csp0,
+                   std::initializer_list<const std::string> expected)
+{
+    Environment env;
+    const Process* process = require_csp0(&env, csp0);
+    Process::Set actual;
+    process->subprocesses(&actual);
+    check_eq(actual, require_csp0_set(&env, expected));
+}
+
+void
 check_initials(const std::string& csp0,
                std::initializer_list<const std::string> expected)
 {
@@ -191,6 +202,7 @@ TEST_CASE("STOP □ STOP")
 {
     auto p = "STOP □ STOP";
     check_name(p, "□ {STOP}");
+    check_subprocesses(p, {"STOP"});
     check_initials(p, {});
     check_afters(p, "a", {});
     check_reachable(p, {"STOP □ STOP"});
@@ -202,6 +214,7 @@ TEST_CASE("(a → STOP) □ (b → STOP ⊓ c → STOP)")
 {
     auto p = "(a → STOP) □ (b → STOP ⊓ c → STOP)";
     check_name(p, "a → STOP □ (b → STOP ⊓ c → STOP)");
+    check_subprocesses(p, {"a → STOP", "b → STOP ⊓ c → STOP"});
     check_initials(p, {"a", "τ"});
     check_afters(p, "a", {"STOP"});
     check_afters(p, "b", {});
@@ -217,6 +230,7 @@ TEST_CASE("(a → STOP) □ (b → STOP)")
 {
     auto p = "(a → STOP) □ (b → STOP)";
     check_name(p, "a → STOP □ b → STOP");
+    check_subprocesses(p, {"a → STOP", "b → STOP"});
     check_initials(p, {"a", "b"});
     check_afters(p, "a", {"STOP"});
     check_afters(p, "b", {"STOP"});
@@ -230,6 +244,7 @@ TEST_CASE("□ {a → STOP, b → STOP, c → STOP}")
 {
     auto p = "□ {a → STOP, b → STOP, c → STOP}";
     check_name(p, "□ {a → STOP, b → STOP, c → STOP}");
+    check_subprocesses(p, {"a → STOP", "b → STOP", "c → STOP"});
     check_initials(p, {"a", "b", "c"});
     check_afters(p, "a", {"STOP"});
     check_afters(p, "b", {"STOP"});
@@ -246,6 +261,7 @@ TEST_CASE("STOP ⫴ STOP")
 {
     auto p = "STOP ⫴ STOP";
     check_name(p, "STOP ⫴ STOP");
+    check_subprocesses(p, {"STOP"});
     check_initials(p, {"✔"});
     check_afters(p, "✔", {"STOP"});
     check_afters(p, "a", {});
@@ -259,6 +275,7 @@ TEST_CASE("(a → STOP) ⫴ (b → STOP ⊓ c → STOP)")
 {
     auto p = "(a → STOP) ⫴ (b → STOP ⊓ c → STOP)";
     check_name(p, "a → STOP ⫴ b → STOP ⊓ c → STOP");
+    check_subprocesses(p, {"a → STOP", "b → STOP ⊓ c → STOP"});
     check_initials(p, {"a", "τ"});
     check_afters(p, "a", {"STOP ⫴ (b → STOP ⊓ c → STOP)"});
     check_afters(p, "b", {});
@@ -277,6 +294,7 @@ TEST_CASE("a → STOP ⫴ a → STOP")
 {
     auto p = "a → STOP ⫴ a → STOP";
     check_name(p, "a → STOP ⫴ a → STOP");
+    check_subprocesses(p, {"a → STOP"});
     check_initials(p, {"a"});
     check_afters(p, "a", {"STOP ⫴ a → STOP"});
     check_afters(p, "b", {});
@@ -291,6 +309,7 @@ TEST_CASE("a → STOP ⫴ b → STOP")
 {
     auto p = "a → STOP ⫴ b → STOP";
     check_name(p, "a → STOP ⫴ b → STOP");
+    check_subprocesses(p, {"a → STOP", "b → STOP"});
     check_initials(p, {"a", "b"});
     check_afters(p, "a", {"STOP ⫴ b → STOP"});
     check_afters(p, "b", {"a → STOP ⫴ STOP"});
@@ -305,6 +324,7 @@ TEST_CASE("a → SKIP ⫴ b → SKIP")
 {
     auto p = "a → SKIP ⫴ b → SKIP";
     check_name(p, "a → SKIP ⫴ b → SKIP");
+    check_subprocesses(p, {"a → SKIP", "b → SKIP"});
     check_initials(p, {"a", "b"});
     check_afters(p, "a", {"SKIP ⫴ b → SKIP"});
     check_afters(p, "b", {"a → SKIP ⫴ SKIP"});
@@ -321,6 +341,7 @@ TEST_CASE("(a → SKIP ⫴ b → SKIP) ; c → STOP")
 {
     auto p = "(a → SKIP ⫴ b → SKIP) ; c → STOP";
     check_name(p, "(a → SKIP ⫴ b → SKIP) ; c → STOP");
+    check_subprocesses(p, {"a → SKIP ⫴ b → SKIP", "c → STOP"});
     check_initials(p, {"a", "b"});
     check_afters(p, "a", {"(SKIP ⫴ b → SKIP) ; c → STOP"});
     check_afters(p, "b", {"(a → SKIP ⫴ SKIP) ; c → STOP"});
@@ -339,6 +360,7 @@ TEST_CASE("⫴ {a → STOP, b → STOP, c → STOP}")
 {
     auto p = "⫴ {a → STOP, b → STOP, c → STOP}";
     check_name(p, "⫴ {a → STOP, b → STOP, c → STOP}");
+    check_subprocesses(p, {"a → STOP", "b → STOP", "c → STOP"});
     check_initials(p, {"a", "b", "c"});
     check_afters(p, "a", {"⫴ {STOP, b → STOP, c → STOP}"});
     check_afters(p, "b", {"⫴ {a → STOP, STOP, c → STOP}"});
@@ -360,6 +382,7 @@ TEST_CASE("STOP ⊓ STOP")
 {
     auto p = "STOP ⊓ STOP";
     check_name(p, "⊓ {STOP}");
+    check_subprocesses(p, {"STOP"});
     check_initials(p, {"τ"});
     check_afters(p, "τ", {"STOP"});
     check_afters(p, "a", {});
@@ -372,6 +395,7 @@ TEST_CASE("(a → STOP) ⊓ (b → STOP)")
 {
     auto p = "(a → STOP) ⊓ (b → STOP)";
     check_name(p, "a → STOP ⊓ b → STOP");
+    check_subprocesses(p, {"a → STOP", "b → STOP"});
     check_initials(p, {"τ"});
     check_afters(p, "τ", {"a → STOP", "b → STOP"});
     check_afters(p, "a", {});
@@ -385,6 +409,7 @@ TEST_CASE("⊓ {a → STOP, b → STOP, c → STOP}")
 {
     auto p = "⊓ {a → STOP, b → STOP, c → STOP}";
     check_name(p, "⊓ {a → STOP, b → STOP, c → STOP}");
+    check_subprocesses(p, {"a → STOP", "b → STOP", "c → STOP"});
     check_initials(p, {"τ"});
     check_afters(p, "τ", {"a → STOP", "b → STOP", "c → STOP"});
     check_afters(p, "a", {});
@@ -401,6 +426,7 @@ TEST_CASE("a → STOP")
 {
     auto p = "a → STOP";
     check_name(p, "a → STOP");
+    check_subprocesses(p, {"STOP"});
     check_initials(p, {"a"});
     check_afters(p, "a", {"STOP"});
     check_afters(p, "τ", {});
@@ -413,6 +439,7 @@ TEST_CASE("a → b → STOP")
 {
     auto p = "a → b → STOP";
     check_name(p, "a → b → STOP");
+    check_subprocesses(p, {"b → STOP"});
     check_initials(p, {"a"});
     check_afters(p, "a", {"b → STOP"});
     check_afters(p, "τ", {});
@@ -427,6 +454,7 @@ TEST_CASE("let X=a → STOP within X")
 {
     auto p = "let X=a → STOP within X";
     check_name(p, "let X=a → STOP within X");
+    check_subprocesses(p, {"a → STOP"});
     check_initials(p, {"a"});
     check_afters(p, "a", {"STOP"});
     check_reachable(p, {"X@0", "STOP"});
@@ -438,6 +466,7 @@ TEST_CASE("let X=a → Y Y=b → X within X")
 {
     auto p = "let X=a → Y Y=b → X within X";
     check_name(p, "let X=a → Y Y=b → X within X");
+    check_subprocesses(p, {"a → Y@0"});
     check_initials(p, {"a"});
     check_afters(p, "a", {"Y@0"});
     check_reachable(p, {"X@0", "Y@0"});
@@ -451,6 +480,7 @@ TEST_CASE("SKIP")
 {
     auto skip = "SKIP";
     check_name(skip, "SKIP");
+    check_subprocesses(skip, {});
     check_initials(skip, {"✔"});
     check_afters(skip, "a", {});
     check_afters(skip, "τ", {});
@@ -466,6 +496,7 @@ TEST_CASE("STOP")
 {
     auto stop = "STOP";
     check_name(stop, "STOP");
+    check_subprocesses(stop, {});
     check_initials(stop, {});
     check_afters(stop, "a", {});
     check_afters(stop, "τ", {});
@@ -480,6 +511,7 @@ TEST_CASE("SKIP ; STOP")
 {
     auto p = "SKIP ; STOP";
     check_name(p, "SKIP ; STOP");
+    check_subprocesses(p, {"SKIP", "STOP"});
     check_initials(p, {"τ"});
     check_afters(p, "a", {});
     check_afters(p, "b", {});
@@ -494,6 +526,7 @@ TEST_CASE("a → SKIP ; STOP")
 {
     auto p = "a → SKIP ; STOP";
     check_name(p, "a → SKIP ; STOP");
+    check_subprocesses(p, {"a → SKIP", "STOP"});
     check_initials(p, {"a"});
     check_afters(p, "a", {"SKIP ; STOP"});
     check_afters(p, "b", {});
@@ -508,6 +541,7 @@ TEST_CASE("(a → b → STOP □ SKIP) ; STOP")
 {
     auto p = "(a → b → STOP □ SKIP) ; STOP";
     check_name(p, "(SKIP □ a → b → STOP) ; STOP");
+    check_subprocesses(p, {"a → b → STOP □ SKIP", "STOP"});
     check_initials(p, {"a", "τ"});
     check_afters(p, "a", {"b → STOP ; STOP"});
     check_afters(p, "b", {});
@@ -523,6 +557,7 @@ TEST_CASE("(a → b → STOP ⊓ SKIP) ; STOP")
 {
     auto p = "(a → b → STOP ⊓ SKIP) ; STOP";
     check_name(p, "(SKIP ⊓ a → b → STOP) ; STOP");
+    check_subprocesses(p, {"a → b → STOP ⊓ SKIP", "STOP"});
     check_initials(p, {"τ"});
     check_afters(p, "a", {});
     check_afters(p, "b", {});
@@ -542,6 +577,7 @@ TEST_CASE("prenormalize {a → STOP}")
 {
     auto p = "prenormalize {a → STOP}";
     check_name(p, "prenormalize {a → STOP}");
+    check_subprocesses(p, {"a → STOP"});
     check_initials(p, {"a"});
     check_afters(p, "a", {"prenormalize {STOP}"});
     check_afters(p, "τ", {});
@@ -555,6 +591,7 @@ TEST_CASE("prenormalize {a → STOP □ b → STOP}")
 {
     auto p = "prenormalize {a → STOP □ b → STOP}";
     check_name(p, "prenormalize {a → STOP □ b → STOP}");
+    check_subprocesses(p, {"a → STOP □ b → STOP"});
     check_initials(p, {"a", "b"});
     check_afters(p, "a", {"prenormalize {STOP}"});
     check_afters(p, "b", {"prenormalize {STOP}"});
@@ -570,6 +607,7 @@ TEST_CASE("prenormalize {a → STOP □ a → b → STOP}")
 {
     auto p = "prenormalize {a → STOP □ a → b → STOP}";
     check_name(p, "prenormalize {a → STOP □ a → b → STOP}");
+    check_subprocesses(p, {"a → STOP □ a → b → STOP"});
     check_initials(p, {"a"});
     check_afters(p, "a", {"prenormalize {STOP, b → STOP}"});
     check_afters(p, "τ", {});
@@ -585,6 +623,7 @@ TEST_CASE("prenormalize {a → STOP ⊓ b → STOP}")
 {
     auto p = "prenormalize {a → STOP ⊓ b → STOP}";
     check_name(p, "prenormalize {a → STOP, b → STOP, a → STOP ⊓ b → STOP}");
+    check_subprocesses(p, {"a → STOP ⊓ b → STOP", "a → STOP", "b → STOP"});
     check_initials(p, {"a", "b"});
     check_afters(p, "a", {"prenormalize {STOP}"});
     check_afters(p, "b", {"prenormalize {STOP}"});
@@ -600,6 +639,7 @@ TEST_CASE("prenormalize {a → SKIP ; b → STOP}")
 {
     auto p = "prenormalize {a → SKIP ; b → STOP}";
     check_name(p, "prenormalize {a → SKIP ; b → STOP}");
+    check_subprocesses(p, {"a → SKIP ; b → STOP"});
     check_initials(p, {"a"});
     check_afters(p, "a", {"prenormalize {SKIP ; b → STOP}"});
     check_afters(p, "τ", {});


### PR DESCRIPTION
This has nothing to do with the behavior of the process; this is the purely syntactic notion of which subprocesses you'd need if you wanted to print out the definition of the process.  (Since the `<<` operator does exactly that, you can see why this might be useful!)