### PR TITLE
Include all subprocesses when printing recursion

### DIFF
--- a/tests/test-operators.cc
+++ b/tests/test-operators.cc
@@ -474,6 +474,21 @@ TEST_CASE("let X=a → Y Y=b → X within X")
     check_traces_behavior(p, {"a"});
 }
 
+TEST_CASE("let X=Y □ Z Y=a → X Z=b → X within X")
+{
+    auto p = "let X=Y □ Z Y=a → X Z=b → X within X";
+    check_name(p, "let X=Y □ Z Y=a → X Z=b → X within X");
+    check_subprocesses(p, {"Y@0 □ Z@0"});
+    check_initials(p, {"a", "b"});
+    check_afters(p, "a", {"X@0"});
+    check_afters(p, "b", {"X@0"});
+    // Y@0 and Z@0 aren't reachable because the external choice "pulls them
+    // apart" when calculating X@0's initials and afters.
+    check_reachable(p, {"X@0"});
+    check_tau_closure(p, {"X@0"});
+    check_traces_behavior(p, {"a", "b"});
+}
+
 TEST_CASE_GROUP("SKIP");
 
 TEST_CASE("SKIP")


### PR DESCRIPTION
Before we used a behavioral definition of reachability to find all of the recursive definitions to include when rendering a `let` statement.  Some operators (e.g. external choice) can pull apart their definitions when producing initials and afters sets, which could "hide" some of the recursive definitions, giving us an incomplete `let` statement.  We actually want to search through the *syntactic* subprocesses, not the *behavioral* ones, when constructing a process's definition.