### PR TITLE
Add refinement checker

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,8 @@ libhst_la_SOURCES = \
 	src/hst/process.cc \
 	src/hst/recursion.h \
 	src/hst/recursion.cc \
+	src/hst/refinement.h \
+	src/hst/refinement.cc \
 	src/hst/semantic-models.h \
 	src/hst/semantic-models.cc \
 	src/hst/sequential-composition.cc
@@ -48,7 +50,8 @@ check_PROGRAMS = \
 	tests/test-harness \
 	tests/test-events \
 	tests/test-csp0 \
-	tests/test-operators
+	tests/test-operators \
+	tests/test-refinement
 
 check_LTLIBRARIES = libtests.la
 libtests_la_SOURCES = \
@@ -61,5 +64,6 @@ tests_test_csp0_LDFLAGS = -no-install
 tests_test_events_LDFLAGS = -no-install
 tests_test_harness_LDFLAGS = -no-install
 tests_test_operators_LDFLAGS = -no-install
+tests_test_refinement_LDFLAGS = -no-install
 
 dist_doc_DATA = README.md

--- a/src/hst/refinement.cc
+++ b/src/hst/refinement.cc
@@ -1,0 +1,169 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#include "hst/refinement.h"
+
+#include <unordered_set>
+
+#include "hst/environment.h"
+#include "hst/event.h"
+#include "hst/hash.h"
+#include "hst/process.h"
+#include "hst/semantic-models.h"
+
+namespace hst {
+
+namespace {
+
+template <typename Model>
+class RefinementPair {
+  public:
+    using Set = std::unordered_set<RefinementPair<Model>>;
+
+    RefinementPair(const NormalizedProcess* spec, const Process* impl)
+        : spec_(spec), impl_(impl)
+    {
+    }
+
+    // Returns whether Spec's behavior refines Impl's behavior.  (This is not a
+    // deep refinement check; it's used to construct the deep refinement check.)
+    bool behavior_refines() const;
+
+    // Returns the initials of Impl
+    void impl_initials(Event::Set* out) const;
+
+    // For a particular Impl initial event, enqueues a new refinement pair for
+    // each Impl after.  Returns false if Spec cannot perform `initial` (meaning
+    // the overall refinement check fails).
+    bool enqueue_afters(Event initial, Set* enqueued, Set* pending) const;
+
+    std::size_t hash() const;
+    bool operator==(const RefinementPair<Model>& other) const;
+
+  private:
+    const NormalizedProcess* spec_;
+    const Process* impl_;
+};
+
+}  // namespace
+
+}  // namespace hst
+
+namespace std {
+
+template <typename Model>
+struct hash<hst::RefinementPair<Model>>
+{
+    std::size_t operator()(const hst::RefinementPair<Model>& pair) const
+    {
+        return pair.hash();
+    }
+};
+
+}  // namespace std
+
+namespace hst {
+
+template <typename Model>
+bool
+RefinementPair<Model>::behavior_refines() const
+{
+    typename Model::Behavior spec_behavior =
+            Model::get_process_behavior(*spec_);
+    typename Model::Behavior impl_behavior =
+            Model::get_process_behavior(*impl_);
+    return spec_behavior.refined_by(impl_behavior);
+}
+
+template <typename Model>
+void
+RefinementPair<Model>::impl_initials(Event::Set* out) const
+{
+    impl_->initials(out);
+}
+
+template <typename Model>
+bool
+RefinementPair<Model>::enqueue_afters(Event initial, Set* enqueued,
+                                      Set* pending) const
+{
+    const NormalizedProcess* spec_after =
+            initial == Event::tau() ? spec_ : spec_->after(initial);
+    if (!spec_after) {
+        // The spec cannot perform this event, so there's no outgoing edge for
+        // the refinement check.
+        return false;
+    }
+
+    // Otherwise we need to create a new refinement pair for the single after of
+    // spec and all of the afters of impl.
+    Process::Set impl_afters;
+    impl_->afters(initial, &impl_afters);
+    for (const Process* impl_after : impl_afters) {
+        RefinementPair pair(spec_after, impl_after);
+        bool added = enqueued->insert(pair).second;
+        if (added) {
+            pending->insert(pair);
+        }
+    }
+    return true;
+}
+
+template <typename Model>
+std::size_t
+RefinementPair<Model>::hash() const
+{
+    static hash_scope refinement;
+    return hasher(refinement).add(spec_).add(impl_).value();
+}
+
+template <typename Model>
+bool
+RefinementPair<Model>::operator==(const RefinementPair<Model>& other) const
+{
+    return spec_ == other.spec_ && impl_ == other.impl_;
+}
+
+template <typename Model>
+bool
+RefinementChecker<Model>::refines(const NormalizedProcess* spec,
+                                  const Process* impl) const
+{
+    typename RefinementPair<Model>::Set enqueued;
+    typename RefinementPair<Model>::Set queue;
+
+    RefinementPair<Model> root(spec, impl);
+    enqueued.insert(root);
+    queue.insert(root);
+
+    while (!queue.empty()) {
+        typename RefinementPair<Model>::Set pending;
+        for (const RefinementPair<Model>& pair : queue) {
+            if (!pair.behavior_refines()) {
+                // TODO: Construct a counterexample
+                return false;
+            }
+
+            Event::Set initials;
+            pair.impl_initials(&initials);
+            for (const Event& initial : initials) {
+                if (!pair.enqueue_afters(initial, &enqueued, &pending)) {
+                    // TODO: Construct a counterexample
+                    return false;
+                }
+            }
+        }
+
+        std::swap(queue, pending);
+    }
+
+    return true;
+}
+
+template class RefinementChecker<Traces>;
+
+}  // namespace hst

--- a/src/hst/refinement.h
+++ b/src/hst/refinement.h
@@ -1,0 +1,25 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef HST_REFINEMENT_H
+#define HST_REFINEMENT_H
+
+#include "hst/environment.h"
+#include "hst/process.h"
+#include "hst/semantic-models.h"
+
+namespace hst {
+
+template <typename Model>
+class RefinementChecker {
+  public:
+    bool refines(const NormalizedProcess* spec, const Process* impl) const;
+};
+
+}  // namespace hst
+
+#endif  // HST_REFINEMENT_H

--- a/src/hst/semantic-models.cc
+++ b/src/hst/semantic-models.cc
@@ -7,6 +7,8 @@
 
 #include "hst/semantic-models.h"
 
+#include <algorithm>
+
 #include "hst/event.h"
 #include "hst/hash.h"
 #include "hst/process.h"
@@ -16,21 +18,34 @@ namespace hst {
 Traces::Behavior
 Traces::get_process_behavior(const Process& process)
 {
-    Traces::Behavior result;
-    process.initials(&result);
-    result.erase(Event::tau());
-    return result;
+    Event::Set events;
+    process.initials(&events);
+    events.erase(Event::tau());
+    return Traces::Behavior(std::move(events));
 }
 
 Traces::Behavior
 Traces::get_process_behavior(const Process::Set& processes)
 {
-    Traces::Behavior result;
+    Event::Set events;
     for (const Process* process : processes) {
-        process->initials(&result);
+        process->initials(&events);
     }
-    result.erase(Event::tau());
-    return result;
+    events.erase(Event::tau());
+    return Traces::Behavior(std::move(events));
+}
+
+bool
+Traces::Behavior::refined_by(const Behavior& impl) const
+{
+    return std::includes(events_.begin(), events_.end(), impl.events_.begin(),
+                         impl.events_.end());
+}
+
+bool
+Traces::Behavior::operator==(const Behavior& other) const
+{
+    return events_ == other.events_;
 }
 
 }  // namespace hst

--- a/tests/test-operators.cc
+++ b/tests/test-operators.cc
@@ -145,7 +145,7 @@ check_traces_behavior(const std::string& csp0,
     Environment env;
     const Process* process = require_csp0(&env, csp0);
     Traces::Behavior actual = Traces::get_process_behavior(*process);
-    check_eq(actual, events_from_names(expected));
+    check_eq(actual.events(), events_from_names(expected));
 }
 
 // Verify the set of non-normalized processes that a normalized process expands

--- a/tests/test-refinement.cc
+++ b/tests/test-refinement.cc
@@ -1,0 +1,109 @@
+/* -*- coding: utf-8 -*-
+ * -----------------------------------------------------------------------------
+ * Copyright © 2017, HST Project.
+ * Please see the COPYING file in this distribution for license details.
+ * -----------------------------------------------------------------------------
+ */
+
+#include <string>
+
+#include "test-cases.h"
+#include "test-harness.cc.in"
+
+#include "hst/csp0.h"
+#include "hst/environment.h"
+#include "hst/event.h"
+#include "hst/process.h"
+#include "hst/refinement.h"
+#include "hst/semantic-models.h"
+
+using hst::Environment;
+using hst::Event;
+using hst::NormalizedProcess;
+using hst::ParseError;
+using hst::Process;
+using hst::RefinementChecker;
+using hst::Traces;
+
+namespace {
+
+const Process*
+require_csp0(Environment* env, const std::string& csp0)
+{
+    ParseError error;
+    const Process* parsed = hst::load_csp0_string(env, csp0, &error);
+    if (!parsed) {
+        fail() << "Could not parse " << csp0 << ": " << error << abort_test();
+    }
+    return parsed;
+}
+
+template <typename Model>
+void
+check_refinement(const std::string& spec_csp0, const std::string& impl_csp0)
+{
+    Environment env;
+    const Process* spec = require_csp0(&env, spec_csp0);
+    const NormalizedProcess* prenormalized_spec = env.prenormalize(spec);
+    const NormalizedProcess* normalized_spec =
+            env.normalize<Model>(prenormalized_spec);
+    const Process* impl = require_csp0(&env, impl_csp0);
+    RefinementChecker<Model> checker;
+    if (!checker.refines(normalized_spec, impl)) {
+        fail() << "Expected refinement to hold: " << spec_csp0 << " ⊑"
+               << Model::abbreviation() << " " << impl_csp0 << abort_test();
+    }
+}
+
+template <typename Model>
+void
+xcheck_refinement(const std::string& spec_csp0, const std::string& impl_csp0)
+{
+    Environment env;
+    const Process* spec = require_csp0(&env, spec_csp0);
+    const NormalizedProcess* prenormalized_spec = env.prenormalize(spec);
+    const NormalizedProcess* normalized_spec =
+            env.normalize<Model>(prenormalized_spec);
+    const Process* impl = require_csp0(&env, impl_csp0);
+    RefinementChecker<Model> checker;
+    if (checker.refines(normalized_spec, impl)) {
+        fail() << "Expected refinement to NOT hold: " << spec_csp0 << " ⊑"
+               << Model::abbreviation() << " " << impl_csp0 << abort_test();
+    }
+}
+
+}  // namespace
+
+TEST_CASE_GROUP("traces refinement");
+
+TEST_CASE("STOP")
+{
+    check_refinement<Traces>("STOP", "STOP");
+    xcheck_refinement<Traces>("STOP", "a → STOP");
+    xcheck_refinement<Traces>("STOP", "a → STOP □ b → STOP");
+    xcheck_refinement<Traces>("STOP", "a → STOP ⊓ b → STOP");
+}
+
+TEST_CASE("a → STOP")
+{
+    check_refinement<Traces>("a → STOP", "STOP");
+    check_refinement<Traces>("a → STOP", "a → STOP");
+    xcheck_refinement<Traces>("a → STOP", "a → STOP □ b → STOP");
+    xcheck_refinement<Traces>("a → STOP", "a → STOP ⊓ b → STOP");
+}
+
+TEST_CASE("a → STOP □ b → STOP")
+{
+    check_refinement<Traces>("a → STOP □ b → STOP", "STOP");
+    check_refinement<Traces>("a → STOP □ b → STOP", "a → STOP");
+    check_refinement<Traces>("a → STOP □ b → STOP", "a → STOP □ b → STOP");
+    check_refinement<Traces>("a → STOP □ b → STOP", "a → STOP ⊓ b → STOP");
+}
+
+TEST_CASE("a → STOP ⊓ b → STOP")
+{
+    check_refinement<Traces>("a → STOP ⊓ b → STOP", "STOP");
+    check_refinement<Traces>("a → STOP ⊓ b → STOP", "a → STOP");
+    check_refinement<Traces>("a → STOP ⊓ b → STOP", "a → STOP □ b → STOP");
+    check_refinement<Traces>("a → STOP ⊓ b → STOP", "a → STOP ⊓ b → STOP");
+}


### PR DESCRIPTION
Now that all of the pieces are in place, we just have to do a BFS through pairs of Spec and Impl processes.  If we find any pair where the Impl subprocess's behavior doesn't refine the Spec subprocess's behavior, the refinement check fails.  If we make it through to the end without finding a bad pair, the check succeeds.