### PR TITLE
Fix hashing and comparison of bags and sets

### DIFF
--- a/src/hst/event.cc
+++ b/src/hst/event.cc
@@ -7,8 +7,10 @@
 
 #include "hst/event.h"
 
+#include <algorithm>
 #include <map>
 #include <ostream>
+#include <vector>
 
 #include "hst/hash.h"
 
@@ -65,8 +67,10 @@ Event::Set::hash() const
 {
     static hash_scope scope;
     hst::hasher hash(scope);
-    for (Event event : *this) {
-        hash.add_unordered(event);
+    std::vector<Event> sorted(begin(), end());
+    std::sort(sorted.begin(), sorted.end());
+    for (const Event event : sorted) {
+        hash.add(event);
     }
     return hash.value();
 }

--- a/src/hst/hash.h
+++ b/src/hst/hash.h
@@ -32,13 +32,6 @@ class hasher {
         return *this;
     }
 
-    template <typename T>
-    hasher& add_unordered(const T& value)
-    {
-        hash_ ^= std::hash<T>()(value);
-        return *this;
-    }
-
     std::size_t value() const { return hash_; }
 
   private:

--- a/src/hst/process.cc
+++ b/src/hst/process.cc
@@ -30,24 +30,12 @@ Process::Bag::hash() const
 {
     static hash_scope scope;
     hst::hasher hash(scope);
-    for (const Process* process : *this) {
-        hash.add_unordered(*process);
+    std::vector<const Process*> sorted(begin(), end());
+    std::sort(sorted.begin(), sorted.end());
+    for (const Process* process : sorted) {
+        hash.add(*process);
     }
     return hash.value();
-}
-
-bool
-operator==(const Process::Bag& lhs, const Process::Bag& rhs)
-{
-    if (lhs.size() != rhs.size()) {
-        return false;
-    }
-    for (const Process* process : lhs) {
-        if (rhs.find(process) == rhs.end()) {
-            return false;
-        }
-    }
-    return true;
 }
 
 std::ostream& operator<<(std::ostream& out, const Process::Bag& processes)
@@ -80,8 +68,10 @@ Process::Set::hash() const
 {
     static hash_scope scope;
     hst::hasher hash(scope);
-    for (const Process* process : *this) {
-        hash.add_unordered(*process);
+    std::vector<const Process*> sorted(begin(), end());
+    std::sort(sorted.begin(), sorted.end());
+    for (const Process* process : sorted) {
+        hash.add(*process);
     }
     return hash.value();
 }
@@ -102,20 +92,6 @@ Process::Set::tau_close()
             return;
         }
     }
-}
-
-bool
-operator==(const Process::Set& lhs, const Process::Set& rhs)
-{
-    if (lhs.size() != rhs.size()) {
-        return false;
-    }
-    for (const Process* process : lhs) {
-        if (rhs.find(process) == rhs.end()) {
-            return false;
-        }
-    }
-    return true;
 }
 
 std::ostream& operator<<(std::ostream& out, const Process::Set& processes)

--- a/src/hst/process.h
+++ b/src/hst/process.h
@@ -138,9 +138,6 @@ class Process::Bag : public std::unordered_multiset<const Process*> {
     std::size_t hash() const;
 };
 
-bool
-operator==(const Process::Bag& lhs, const Process::Bag& rhs);
-
 std::ostream& operator<<(std::ostream& out, const Process::Bag& processes);
 
 class Process::Set : public std::unordered_set<const Process*> {
@@ -156,9 +153,6 @@ class Process::Set : public std::unordered_set<const Process*> {
     // additional processes you can reach by following τ one or more times.)
     void tau_close();
 };
-
-bool
-operator==(const Process::Set& lhs, const Process::Set& rhs);
 
 std::ostream& operator<<(std::ostream& out, const Process::Set& processes);
 

--- a/tests/test-operators.cc
+++ b/tests/test-operators.cc
@@ -196,6 +196,51 @@ TEST_CASE("can compare sets of processes")
     check_eq(set1, set2);
 }
 
+TEST_CASE("process equality considers contents of sets")
+{
+    Environment env;
+    auto p1 = require_csp0(&env, "□ {}");
+    auto p2 = require_csp0(&env, "□ {a → STOP}");
+    auto p3 = require_csp0(&env, "□ {a → STOP, b → STOP}");
+    auto p4 = require_csp0(&env, "□ {a → STOP, b → STOP, c → STOP}");
+    check_ne(p1, p2);
+    check_ne(p1, p3);
+    check_ne(p1, p4);
+    check_ne(p2, p3);
+    check_ne(p2, p4);
+    check_ne(p3, p4);
+}
+
+TEST_CASE("process equality considers contents of bags")
+{
+    Environment env;
+    auto p1 = require_csp0(&env, "⫴ {}");
+    auto p2 = require_csp0(&env, "⫴ {a → STOP}");
+    auto p3 = require_csp0(&env, "⫴ {a → STOP, b → STOP}");
+    auto p4 = require_csp0(&env, "⫴ {a → STOP, b → STOP, c → STOP}");
+    check_ne(p1, p2);
+    check_ne(p1, p3);
+    check_ne(p1, p4);
+    check_ne(p2, p3);
+    check_ne(p2, p4);
+    check_ne(p3, p4);
+}
+
+TEST_CASE("process equality considers cardinality of contents of bags")
+{
+    Environment env;
+    auto p1 = require_csp0(&env, "⫴ {a→b→STOP, a→b→STOP, a→b→STOP}");
+    auto p2 = require_csp0(&env, "⫴ {a→b→STOP, a→b→STOP, b→STOP  }");
+    auto p3 = require_csp0(&env, "⫴ {a→b→STOP, b→STOP,   b→STOP  }");
+    auto p4 = require_csp0(&env, "⫴ {b→STOP,   b→STOP,   b→STOP  }");
+    check_ne(p1, p2);
+    check_ne(p1, p3);
+    check_ne(p1, p4);
+    check_ne(p2, p3);
+    check_ne(p2, p4);
+    check_ne(p3, p4);
+}
+
 TEST_CASE_GROUP("external choice");
 
 TEST_CASE("STOP □ STOP")


### PR DESCRIPTION
I was being sloppy with the hashing of bags and sets, using a bare XOR when I should really be mixing in the elements properly.  It's not as much of a problem for sets, since we're guaranteed that each element will appear at most once (so the `x ^ x == 0` problem can't happen).  With bags it's a real problem, though.  But if I'm going to fix one, I might as well fix both.