### PR TITLE
Find maximal finite traces of a process

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,7 +41,8 @@ libhst_la_SOURCES = \
 hst_SOURCES = \
 	src/hst/hst/command.h \
 	src/hst/hst/hst.cc \
-	src/hst/hst/reachable.cc
+	src/hst/hst/reachable.cc \
+	src/hst/hst/traces.cc
 hst_LDADD = libhst.la
 
 # Keep this sorted generally in order of dependency, so that more basic features

--- a/src/hst/hst/command.h
+++ b/src/hst/hst/command.h
@@ -23,9 +23,15 @@ class Command {
     std::string name_;
 };
 
-class Reachable : public Command {
+class ReachableCommand : public Command {
   public:
-    Reachable() : Command("reachable") {}
+    ReachableCommand() : Command("reachable") {}
+    void run(int argc, char** argv) override;
+};
+
+class TracesCommand : public Command {
+  public:
+    TracesCommand() : Command("traces") {}
     void run(int argc, char** argv) override;
 };
 

--- a/src/hst/hst/hst.cc
+++ b/src/hst/hst/hst.cc
@@ -11,8 +11,9 @@
 
 #include "hst/hst/command.h"
 
-static hst::Reachable reachable;
-static std::vector<hst::Command*> commands{&reachable};
+static hst::ReachableCommand reachable;
+static hst::TracesCommand traces;
+static std::vector<hst::Command*> commands{&reachable, &traces};
 
 int
 main(int argc, char** argv)

--- a/src/hst/hst/traces.cc
+++ b/src/hst/hst/traces.cc
@@ -14,11 +14,12 @@
 #include "hst/csp0.h"
 #include "hst/environment.h"
 #include "hst/process.h"
+#include "hst/semantic-models.h"
 
 namespace hst {
 
 void
-ReachableCommand::run(int argc, char** argv)
+TracesCommand::run(int argc, char** argv)
 {
     bool verbose = false;
     static struct option options[] = {{"verbose", no_argument, 0, 'v'},
@@ -43,7 +44,7 @@ ReachableCommand::run(int argc, char** argv)
     argc -= optind, argv += optind;
 
     if (argc != 1) {
-        std::cerr << "Usage: hst reachable [-v] <process>" << std::endl;
+        std::cerr << "Usage: hst traces [-v] <process>" << std::endl;
         exit(EXIT_FAILURE);
     }
 
@@ -58,15 +59,15 @@ ReachableCommand::run(int argc, char** argv)
     }
 
     unsigned long count = 0;
-    process->bfs([&count, verbose](const Process* process) {
-        if (verbose) {
-            std::cout << *process << std::endl;
-        }
-        count++;
-        return true;
-    });
+    find_maximal_finite_traces(&env, process,
+                               [&count, verbose](const Trace& trace) {
+                                   if (verbose) {
+                                       std::cout << trace << std::endl;
+                                   }
+                                   count++;
+                               });
     if (verbose) {
-        std::cout << "Reachable processes: ";
+        std::cout << "Maximal finite traces: ";
     }
     std::cout << count << std::endl;
 }

--- a/src/hst/interleave.cc
+++ b/src/hst/interleave.cc
@@ -81,18 +81,25 @@ Interleave::initials(Event::Set* out) const
     //                ∪ ⋃ { (✔ ∈ initials(P)? {τ}: {}) | P ∈ Ps }       [rule 3]
     //                ∪ (Ps = {STOP}? {✔}: {})                          [rule 4]
 
+    // We have to use this intermediary set because we need to detect whether
+    // our subprocesses fill it in, and we can't depend on the caller passing us
+    // an empty `out`.
+    Event::Set initials;
+
     // Rules 1 and 2
     for (const Process* process : ps_) {
-        process->initials(out);
+        process->initials(&initials);
     }
     // Rule 3
-    if (out->erase(Event::tick()) > 0) {
-        out->insert(Event::tau());
+    if (initials.erase(Event::tick()) > 0) {
+        initials.insert(Event::tau());
     }
     // Rule 4
-    if (out->empty()) {
-        out->insert(Event::tick());
+    if (initials.empty()) {
+        initials.insert(Event::tick());
     }
+
+    out->insert(initials.begin(), initials.end());
 }
 
 void

--- a/src/hst/semantic-models.cc
+++ b/src/hst/semantic-models.cc
@@ -15,6 +15,22 @@
 
 namespace hst {
 
+std::ostream&
+operator<<(std::ostream& out, const Trace& trace)
+{
+    out << "⟨";
+    bool first = true;
+    for (const Event event : trace) {
+        if (first) {
+            first = false;
+        } else {
+            out << ",";
+        }
+        out << event;
+    }
+    return out << "⟩";
+}
+
 Traces::Behavior
 Traces::get_process_behavior(const Process& process)
 {

--- a/src/hst/semantic-models.h
+++ b/src/hst/semantic-models.h
@@ -8,10 +8,64 @@
 #ifndef HST_SEMANTIC_MODELS_H
 #define HST_SEMANTIC_MODELS_H
 
+#include <ostream>
+#include <vector>
+
+#include "hst/environment.h"
 #include "hst/event.h"
 #include "hst/process.h"
 
 namespace hst {
+
+//------------------------------------------------------------------------------
+// Traces
+
+class Trace {
+  private:
+    using TraceVector = std::vector<Event>;
+
+  public:
+    using const_iterator = TraceVector::const_iterator;
+    using size_type = TraceVector::size_type;
+
+    // Creates a new empty trace
+    Trace() = default;
+
+    explicit Trace(std::vector<Event> events) : events_(std::move(events)) {}
+
+    // Creates a new trace that is an extension of the current one.
+    Trace extend(Event suffix) const { return Trace(*this, suffix); }
+
+    const_iterator begin() const { return events_.begin(); }
+    const_iterator end() const { return events_.end(); }
+    bool empty() const { return events_.empty(); }
+    size_type size() const { return events_.size(); }
+
+    bool operator==(const Trace& other) const
+    {
+        return events_ == other.events_;
+    }
+
+    bool operator!=(const Trace& other) const { return !(*this == other); }
+
+  private:
+    Trace(const Trace& prefix, Event suffix) : events_(prefix.events_)
+    {
+        events_.push_back(suffix);
+    }
+
+    TraceVector events_;
+};
+
+std::ostream&
+operator<<(std::ostream& out, const Trace& trace);
+
+template <typename F>
+void
+find_maximal_finite_traces(Environment* env, const Process* process, F op);
+
+//------------------------------------------------------------------------------
+// Semantic models
 
 #if 0
 // Each semantic model is defined by a struct that must implement the following
@@ -66,5 +120,79 @@ struct hash<hst::Traces::Behavior>
 };
 
 }  // namespace std
+
+//------------------------------------------------------------------------------
+// Internals!
+
+namespace hst {
+
+namespace internal {
+
+struct ProcessList {
+    const NormalizedProcess* process;
+    ProcessList* prev;
+
+    ProcessList() : process(nullptr), prev(nullptr) {}
+    ProcessList(const NormalizedProcess* process, ProcessList* prev)
+        : process(process), prev(prev)
+    {
+    }
+
+    bool contains(const NormalizedProcess* process) const {
+        for (const ProcessList* curr = this; curr; curr = curr->prev) {
+            if (curr->process == process) {
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
+}  // namespace internal
+
+template <typename F>
+void
+find_maximal_finite_traces_(const NormalizedProcess* process,
+                            internal::ProcessList processes,
+                            const Trace& prefix, const F& op)
+{
+    Event::Set initials;
+    process->initials(&initials);
+
+    // If the current process doesn't have any outgoing transitions, we've found
+    // the end of a finite trace.
+    if (initials.empty()) {
+        op(prefix);
+        return;
+    }
+
+    // If `process` already appears earlier in the current trace, then we've
+    // found a cycle.
+    if (processes.contains(process)) {
+        op(prefix);
+        return;
+    }
+
+    for (const Event initial : initials) {
+        const NormalizedProcess* after = process->after(initial);
+        find_maximal_finite_traces_(after,
+                                    internal::ProcessList(process, &processes),
+                                    prefix.extend(initial), op);
+    }
+}
+
+template <typename F>
+void
+find_maximal_finite_traces(Environment* env, const Process* process, F op)
+{
+    // The prenormalization code can do most of the work for us; it will give us
+    // a bunch of subprocesses with at most one outgoing transition for any
+    // event.  We then just have to walk through its edges.
+    const NormalizedProcess* prenormalized = env->prenormalize(process);
+    find_maximal_finite_traces_(prenormalized, internal::ProcessList(), Trace(),
+                                op);
+}
+
+}  // namespace hst
 
 #endif  // HST_SEMANTIC_MODELS_H


### PR DESCRIPTION
This will be useful for performance testing, because it requires walking the full expansion of the process's behavior.  (Just looking for reachable processes doesn't, since our memoization trims redundant branches pretty aggressively.)