### PR TITLE
Use visitors in initials and afters methods

### DIFF
--- a/src/hst/environment.cc
+++ b/src/hst/environment.cc
@@ -7,6 +7,8 @@
 
 #include "hst/environment.h"
 
+#include <functional>
+
 #include "hst/hash.h"
 
 namespace hst {
@@ -16,9 +18,9 @@ namespace {
 class Skip : public Process {
   public:
     explicit Skip(const Process* stop) : stop_(stop) {}
-    void initials(Event::Set* out) const override;
-    void afters(Event initial, Process::Set* out) const override;
-    void subprocesses(Process::Set* out) const override;
+    void initials(std::function<void(Event)> op) const override;
+    void afters(Event initial, std::function<void(const Process&)> op) const override;
+    void subprocesses(std::function<void(const Process&)> op) const override;
 
     std::size_t hash() const override;
     bool operator==(const Process& other) const override;
@@ -32,21 +34,21 @@ class Skip : public Process {
 }  // namespace
 
 void
-Skip::initials(Event::Set* out) const
+Skip::initials(std::function<void(Event)> op) const
 {
-    out->insert(Event::tick());
+    op(Event::tick());
 }
 
 void
-Skip::afters(Event initial, Process::Set* out) const
+Skip::afters(Event initial, std::function<void(const Process&)> op) const
 {
     if (initial == Event::tick()) {
-        out->insert(stop_);
+        op(*stop_);
     }
 }
 
 void
-Skip::subprocesses(Process::Set* out) const
+Skip::subprocesses(std::function<void(const Process&)> op) const
 {
 }
 
@@ -79,9 +81,9 @@ class Stop : public Process {
   public:
     Stop() = default;
 
-    void initials(Event::Set* out) const override;
-    void afters(Event initial, Process::Set* out) const override;
-    void subprocesses(Process::Set* out) const override;
+    void initials(std::function<void(Event)> op) const override;
+    void afters(Event initial, std::function<void(const Process&)> op) const override;
+    void subprocesses(std::function<void(const Process&)> op) const override;
 
     std::size_t hash() const override;
     bool operator==(const Process& other) const override;
@@ -92,17 +94,17 @@ class Stop : public Process {
 }  // namespace
 
 void
-Stop::initials(Event::Set* out) const
+Stop::initials(std::function<void(Event)> op) const
 {
 }
 
 void
-Stop::afters(Event initial, Process::Set* out) const
+Stop::afters(Event initial, std::function<void(const Process&)> op) const
 {
 }
 
 void
-Stop::subprocesses(Process::Set* out) const
+Stop::subprocesses(std::function<void(const Process&)> op) const
 {
 }
 

--- a/src/hst/hst/reachable.cc
+++ b/src/hst/hst/reachable.cc
@@ -58,9 +58,9 @@ ReachableCommand::run(int argc, char** argv)
     }
 
     unsigned long count = 0;
-    process->bfs([&count, verbose](const Process* process) {
+    process->bfs([&count, verbose](const Process& process) {
         if (verbose) {
-            std::cout << *process << std::endl;
+            std::cout << process << std::endl;
         }
         count++;
         return true;

--- a/src/hst/interleave.cc
+++ b/src/hst/interleave.cc
@@ -7,6 +7,7 @@
 
 #include "hst/environment.h"
 
+#include <functional>
 #include <string>
 
 #include "hst/event.h"
@@ -24,9 +25,10 @@ class Interleave : public Process {
     {
     }
 
-    void initials(Event::Set* out) const override;
-    void afters(Event initial, Process::Set* out) const override;
-    void subprocesses(Process::Set* out) const override;
+    void initials(std::function<void(Event)> op) const override;
+    void afters(Event initial,
+                std::function<void(const Process&)> op) const override;
+    void subprocesses(std::function<void(const Process&)> op) const override;
 
     std::size_t hash() const override;
     bool operator==(const Process& other) const override;
@@ -34,9 +36,14 @@ class Interleave : public Process {
     void print(std::ostream& out) const override;
 
   private:
-    void normal_afters(Event initial, Process::Set* out) const;
-    void tau_afters(Event initial, Process::Set* out) const;
-    void tick_afters(Event initial, Process::Set* out) const;
+    void
+    normal_afters(Event initial, std::function<void(const Process&)> op) const;
+
+    void
+    tau_afters(Event initial, std::function<void(const Process&)> op) const;
+
+    void
+    tick_afters(Event initial, std::function<void(const Process&)> op) const;
 
     Environment* env_;
     Process::Bag ps_;
@@ -74,36 +81,36 @@ Environment::interleave(const Process* p, const Process* q)
 //       ⫴ {STOP} -✔→ STOP
 
 void
-Interleave::initials(Event::Set* out) const
+Interleave::initials(std::function<void(Event)> op) const
 {
     // initials(⫴ Ps) = ⋃ { initials(P) ∩ {τ} | P ∈ Ps }                [rule 1]
     //                ∪ ⋃ { initials(P) ∖ {τ,✔} | P ∈ Ps }              [rule 2]
     //                ∪ ⋃ { (✔ ∈ initials(P)? {τ}: {}) | P ∈ Ps }       [rule 3]
     //                ∪ (Ps = {STOP}? {✔}: {})                          [rule 4]
 
-    // We have to use this intermediary set because we need to detect whether
-    // our subprocesses fill it in, and we can't depend on the caller passing us
-    // an empty `out`.
-    Event::Set initials;
+    bool any_events = false;
+    for (const Process* p : ps_) {
+        p->initials([&any_events, &op](Event initial) {
+            any_events = true;
+            if (initial == Event::tick()) {
+                // Rule 3
+                op(Event::tau());
+            } else {
+                // Rules 1 and 2
+                op(initial);
+            }
+        });
+    }
 
-    // Rules 1 and 2
-    for (const Process* process : ps_) {
-        process->initials(&initials);
-    }
-    // Rule 3
-    if (initials.erase(Event::tick()) > 0) {
-        initials.insert(Event::tau());
-    }
     // Rule 4
-    if (initials.empty()) {
-        initials.insert(Event::tick());
+    if (!any_events) {
+        op(Event::tick());
     }
-
-    out->insert(initials.begin(), initials.end());
 }
 
 void
-Interleave::normal_afters(Event initial, Process::Set* out) const
+Interleave::normal_afters(Event initial,
+                          std::function<void(const Process&)> op) const
 {
     // afters(⫴ Ps, a ∉ {τ,✔}) = ⋃ { ⫴ Ps ∖ {P} ∪ {P'} |
     //                                  P ∈ Ps, P' ∈ afters(P, a) }     [rule 2]
@@ -116,31 +123,30 @@ Interleave::normal_afters(Event initial, Process::Set* out) const
         // Set Ps' to Ps ∖ {P}
         ps_prime.erase(ps_prime.find(p));
         // Grab afters(P, a)
-        Process::Set p_afters;
-        p->afters(initial, &p_afters);
-        for (const Process* p_prime : p_afters) {
+        p->afters(initial, [this, &op, &ps_prime](const Process& p_prime) {
             // ps_prime currently contains Ps.  Add P' and remove P to produce
             // (Ps ∖ {P} ∪ {P'})
-            ps_prime.insert(p_prime);
+            ps_prime.insert(&p_prime);
             // Create ⫴ (Ps ∖ {P} ∪ {P'}) as a result.
-            out->insert(env_->interleave(ps_prime));
+            op(*env_->interleave(ps_prime));
             // Reset Ps' back to Ps ∖ {P}.
-            ps_prime.erase(ps_prime.find(p_prime));
-        }
+            ps_prime.erase(ps_prime.find(&p_prime));
+        });
         // Reset Ps' back to Ps.
         ps_prime.insert(p);
     }
 }
 
 void
-Interleave::tau_afters(Event initial, Process::Set* out) const
+Interleave::tau_afters(Event initial,
+                       std::function<void(const Process&)> op) const
 {
     // afters(⫴ Ps, τ) = ⋃ { ⫴ Ps ∖ {P} ∪ {P'} | P ∈ Ps, P' ∈ afters(P, τ) }
     //                                                                  [rule 1]
     //                 ∪ ⋃ { ⫴ Ps ∖ {P} ∪ {STOP} | P ∈ Ps, P' ∈ afters(P, ✔) }
     //                                                                  [rule 3]
     // Rule 1 has the same form as rule 2, which we've implemented above.*/
-    normal_afters(initial, out);
+    normal_afters(initial, op);
     // Rule 3...does not.
     // We're going to build up a lot of new Ps' sets that all have the same
     // basic structure: Ps' = Ps ∖ {P} ∪ {STOP}.  Each Ps' starts with Ps, so go
@@ -148,13 +154,17 @@ Interleave::tau_afters(Event initial, Process::Set* out) const
     Process::Bag ps_prime(ps_);
     // Find each P ∈ Ps where ✔ ∈ initials(P).
     for (const Process* p : ps_) {
-        Event::Set initials;
-        p->initials(&initials);
-        if (initials.find(Event::tick()) != initials.end()) {
+        bool any_tick = false;
+        p->initials([&any_tick](Event initial) {
+            if (initial == Event::tick()) {
+                any_tick = true;
+            }
+        });
+        if (any_tick) {
             // Create Ps ∖ {P} ∪ {STOP}) as a result.
             ps_prime.erase(ps_prime.find(p));
             ps_prime.insert(env_->stop());
-            out->insert(env_->interleave(ps_prime));
+            op(*env_->interleave(ps_prime));
             // Reset Ps' back to Ps.
             ps_prime.erase(ps_prime.find(env_->stop()));
             ps_prime.insert(p);
@@ -163,37 +173,40 @@ Interleave::tau_afters(Event initial, Process::Set* out) const
 }
 
 void
-Interleave::tick_afters(Event initial, Process::Set* out) const
+Interleave::tick_afters(Event initial,
+                        std::function<void(const Process&)> op) const
 {
     // afters(⫴ {STOP}, ✔) = {STOP}                                     [rule 4]
     for (const Process* p : ps_) {
-        Event::Set initials;
-        p->initials(&initials);
-        if (!initials.empty()) {
+        bool any_events = false;
+        p->initials([&any_events](Event _) { any_events = true; });
+        if (any_events) {
             // One of the subprocesses has at least one initial, so this cannot
             // possibly be ⫴ {STOP}.
             return;
         }
     }
-    out->insert(env_->stop());
+    op(*env_->stop());
 }
 
 void
-Interleave::afters(Event initial, Process::Set* out) const
+Interleave::afters(Event initial, std::function<void(const Process&)> op) const
 {
     if (initial == Event::tau()) {
-        tau_afters(initial, out);
+        tau_afters(initial, op);
     } else if (initial == Event::tick()) {
-        tick_afters(initial, out);
+        tick_afters(initial, op);
     } else {
-        normal_afters(initial, out);
+        normal_afters(initial, op);
     }
 }
 
 void
-Interleave::subprocesses(Process::Set* out) const
+Interleave::subprocesses(std::function<void(const Process&)> op) const
 {
-    out->insert(ps_.begin(), ps_.end());
+    for (const Process* process : ps_) {
+        op(*process);
+    }
 }
 
 std::size_t

--- a/src/hst/prefix.cc
+++ b/src/hst/prefix.cc
@@ -7,6 +7,7 @@
 
 #include "hst/environment.h"
 
+#include <functional>
 #include <memory>
 #include <ostream>
 
@@ -21,9 +22,10 @@ namespace {
 class Prefix : public Process {
   public:
     Prefix(Event a, const Process* p) : a_(a), p_(p) {}
-    void initials(Event::Set* out) const override;
-    void afters(Event initial, Process::Set* out) const override;
-    void subprocesses(Process::Set* out) const override;
+    void initials(std::function<void(Event)> op) const override;
+    void afters(Event initial,
+                std::function<void(const Process&)> op) const override;
+    void subprocesses(std::function<void(const Process&)> op) const override;
 
     std::size_t hash() const override;
     bool operator==(const Process& other) const override;
@@ -49,25 +51,25 @@ Environment::prefix(Event a, const Process* p)
 //     a → P -a→ P
 
 void
-Prefix::initials(Event::Set* out) const
+Prefix::initials(std::function<void(Event)> op) const
 {
     // initials(a → P) = {a}
-    out->insert(a_);
+    op(a_);
 }
 
 void
-Prefix::afters(Event initial, Process::Set* out) const
+Prefix::afters(Event initial, std::function<void(const Process&)> op) const
 {
     // afters(a → P, a) = P
     if (initial == a_) {
-        out->insert(p_);
+        op(*p_);
     }
 }
 
 void
-Prefix::subprocesses(Process::Set* out) const
+Prefix::subprocesses(std::function<void(const Process&)> op) const
 {
-    out->insert(p_);
+    op(*p_);
 }
 
 std::size_t

--- a/src/hst/process.cc
+++ b/src/hst/process.cc
@@ -17,11 +17,30 @@
 namespace hst {
 
 void
-NormalizedProcess::afters(Event initial, Set* out) const
+Process::initials(Event::Set* out) const
+{
+    initials([&out](Event event) { out->insert(event); });
+}
+
+void
+Process::afters(Event initial, Process::Set* out) const
+{
+    afters(initial, [&out](const Process& process) { out->insert(&process); });
+}
+
+void
+Process::subprocesses(Process::Set* out) const
+{
+    subprocesses([&out](const Process& process) { out->insert(&process); });
+}
+
+void
+NormalizedProcess::afters(Event initial,
+                          std::function<void(const Process&)> op) const
 {
     const NormalizedProcess* process = after(initial);
     if (process) {
-        out->insert(process);
+        op(*process);
     }
 }
 

--- a/src/hst/recursion.h
+++ b/src/hst/recursion.h
@@ -8,6 +8,7 @@
 #ifndef HST_RECURSION_H
 #define HST_RECURSION_H
 
+#include <functional>
 #include <string>
 #include <unordered_map>
 
@@ -51,9 +52,10 @@ class RecursiveProcess : public Process {
     {
     }
 
-    void initials(Event::Set* out) const override;
-    void afters(Event initial, Process::Set* out) const override;
-    void subprocesses(Process::Set* out) const override;
+    void initials(std::function<void(Event)> op) const override;
+    void afters(Event initial,
+                std::function<void(const Process&)> op) const override;
+    void subprocesses(std::function<void(const Process&)> op) const override;
 
     const std::string& name() const { return name_; }
     const Process* definition() const { return definition_; }

--- a/tests/test-operators.cc
+++ b/tests/test-operators.cc
@@ -132,8 +132,8 @@ check_reachable(const std::string& csp0,
     Environment env;
     const Process* process = require_csp0(&env, csp0);
     Process::Set actual;
-    process->bfs([&actual](const Process* process) {
-        actual.insert(process);
+    process->bfs([&actual](const Process& process) {
+        actual.insert(&process);
         return true;
     });
     check_eq(actual, require_csp0_set(&env, expected));
@@ -201,7 +201,8 @@ check_expansion(const std::string& csp0,
             dynamic_cast<const NormalizedProcess*>(process);
     assert(normalized);
     Process::Set actual;
-    normalized->expand(&actual);
+    normalized->expand(
+            [&actual](const Process& process) { actual.insert(&process); });
     check_eq(actual, require_csp0_set(&env, expected));
 }
 


### PR DESCRIPTION
Instead of always rendering into an output set, you now provide an std::function visitor that we'll call for each event or process in the result.