### PR TITLE
Better representation for process bags

### DIFF
--- a/src/hst/process.cc
+++ b/src/hst/process.cc
@@ -8,6 +8,7 @@
 #include "hst/process.h"
 
 #include <algorithm>
+#include <assert.h>
 #include <string>
 #include <utility>
 #include <vector>
@@ -44,34 +45,57 @@ NormalizedProcess::afters(Event initial,
     }
 }
 
+void
+Process::Bag::insert(const Process* process)
+{
+    ++counts_[process];
+}
+
+void
+Process::Bag::erase(const Process* process)
+{
+    auto it = counts_.find(process);
+    assert(it != counts_.end() && it->second != 0);
+    if (--it->second == 0) {
+        counts_.erase(it);
+    }
+}
+
 std::size_t
 Process::Bag::hash() const
 {
     static hash_scope scope;
     hst::hasher hash(scope);
-    std::vector<const Process*> sorted(begin(), end());
-    std::sort(sorted.begin(), sorted.end());
-    for (const Process* process : sorted) {
+    for (const Process* process : sorted()) {
         hash.add(*process);
     }
     return hash.value();
 }
 
-std::ostream& operator<<(std::ostream& out, const Process::Bag& processes)
+std::vector<const Process*>
+Process::Bag::sorted() const
 {
-    // We want reproducible output, so we sort the processes in the set before
-    // rendering them into the stream.  We the process's index to print out the
-    // processes in the order that they were defined.
-    std::vector<const Process*> sorted_processes(processes.begin(),
-                                                 processes.end());
-    std::sort(sorted_processes.begin(), sorted_processes.end(),
+    std::vector<const Process*> sorted;
+    for (const auto& process_and_count : *this) {
+        const Process* process = process_and_count.first;
+        size_type count = process_and_count.second;
+        sorted.insert(sorted.end(), count, process);
+    }
+    std::sort(sorted.begin(), sorted.end(),
               [](const Process* p1, const Process* p2) {
                   return p1->index() < p2->index();
               });
+    return sorted;
+}
 
+std::ostream& operator<<(std::ostream& out, const Process::Bag& processes)
+{
+    // We want reproducible output, so we sort the processes in the set before
+    // rendering them into the stream.  We use the process's index as the sort
+    // key to print out the processes in the order that they were defined.
     bool first = true;
     out << "{";
-    for (const Process* process : sorted_processes) {
+    for (const Process* process : processes.sorted()) {
         if (first) {
             first = false;
         } else {
@@ -87,12 +111,21 @@ Process::Set::hash() const
 {
     static hash_scope scope;
     hst::hasher hash(scope);
-    std::vector<const Process*> sorted(begin(), end());
-    std::sort(sorted.begin(), sorted.end());
-    for (const Process* process : sorted) {
+    for (const Process* process : sorted()) {
         hash.add(*process);
     }
     return hash.value();
+}
+
+std::vector<const Process*>
+Process::Set::sorted() const
+{
+    std::vector<const Process*> sorted(begin(), end());
+    std::sort(sorted.begin(), sorted.end(),
+              [](const Process* p1, const Process* p2) {
+                  return p1->index() < p2->index();
+              });
+    return sorted;
 }
 
 void
@@ -118,16 +151,9 @@ std::ostream& operator<<(std::ostream& out, const Process::Set& processes)
     // We want reproducible output, so we sort the processes in the set before
     // rendering them into the stream.  We the process's index to print out the
     // processes in the order that they were defined.
-    std::vector<const Process*> sorted_processes(processes.begin(),
-                                                 processes.end());
-    std::sort(sorted_processes.begin(), sorted_processes.end(),
-              [](const Process* p1, const Process* p2) {
-                  return p1->index() < p2->index();
-              });
-
     bool first = true;
     out << "{";
-    for (const Process* process : sorted_processes) {
+    for (const Process* process : processes.sorted()) {
         if (first) {
             first = false;
         } else {


### PR DESCRIPTION
The STL version seems to store each copy of each process individually, and each element of the map seems to require its own memory allocation.  That's a lot of memory churn, especially when you insert and remove elements from a bag in quick succession, just like we do when calculating the afters of an interleave process.